### PR TITLE
Optimize temporal client initialization

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/rakyll/statik/fs"
 	"github.com/temporalio/web-go/server/routes"
+	"github.com/temporalio/web-go/server/temporal"
 )
 
 type (
@@ -49,7 +50,12 @@ func NewServer() *Server {
 	// Middleware
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
-	routes.SetAPIRoutes(e)
+
+	tClient, err := temporal.NewClient("127.0.0.1:7233")
+	if err != nil {
+		e.Logger.Fatal(err)
+	}
+	routes.SetAPIRoutes(e, tClient)
 
 	statikFS, err := fs.New()
 	if err != nil {

--- a/server/temporal/temporal.go
+++ b/server/temporal/temporal.go
@@ -48,11 +48,11 @@ type (
 // NewClient creates a new frontend service gRPC client
 func NewClient(
 	rpcAddress string,
-) (Client, error) {
+) (*Client, error) {
 	connection := rpc.CreateFrontendGRPCConnection(rpcAddress)
 	frontend := workflowservice.NewWorkflowServiceClient(connection)
 	client := Client{frontend: frontend, timeout: DefaultTimeout}
-	return client, nil
+	return &client, nil
 }
 
 func (c *Client) createContext(parent context.Context) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
Before it was creating a temporal client on each request. Switched to initializing on server startup