### PR TITLE
Move all generated artifacts under generated folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build: build-client build-server
 
 build-client:
 	(cd client && yarn build)
-	statik -src=./client/build
+	statik -m -f -dest generated/web -src=./client/build
 
 build-server: build-grpc
 	go mod tidy
@@ -53,12 +53,11 @@ build-grpc:
 	mv -f $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
 
 	# Generate static assets for OpenAPI UI
-	statik -m -f -src third_party/OpenAPI/
+	statik -m -f -dest generated/openapi -src third_party/OpenAPI/
 
 clean:
-	rm -rf ./api
+	rm -rf ./generated/openapi ./generated/web
 	(cd client && rm -rf ./build)
-	rm -rf ./statik
 
 ##### Install dependencies #####
 install: install-utils install-client

--- a/server/server.go
+++ b/server/server.go
@@ -27,7 +27,7 @@ import (
 	"net/http"
 
 	// statik build output
-	_ "github.com/temporalio/web-go/statik"
+	_ "github.com/temporalio/web-go/generated/web/statik"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"


### PR DESCRIPTION
<!--- Reminder to change the title 👆 -->

Moves Web, OpenAPi and API (proto files) build output artifacts under generated folder

<!--- For All  Contributors -->

<!--- What was changed? Is this a bugfix or new feature? Include screenshots if relevant -->
What was changed:
OpenApi and Web client statik builds are moved under the folder `generated`

<!--- Why is this change required? What problem does it solve? -->
Motivation & Context:
These build outputs are part of the repo itself because go server depends on these outputs (helpful when consuming current repo as an external lib), so for new developers the name of the folder will suggest they shouldn't change anything directly 
![image](https://user-images.githubusercontent.com/11838981/112050108-b6a47900-8b0d-11eb-9361-89dc550eb0da.png)

<!--- If it fixes an open issue, please link to the issue here. -->
Closes issue: 

## How has this been tested?
<!--- Please describe how you tested your changes/how we can test them -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
