### PR TITLE
Switch to serving new UI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ui"]
+	path = ui
+	url = https://github.com/temporalio/ui

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,15 @@ PROTO_IMPORTS := \
 	-I proto/dependencies/
 PROTO_REFS := Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/api/annotations.proto=github.com/gogo/googleapis/google/api
 SWAGGERUI_OUT := ./server/generated/swagger-ui
-WEBUI_OUT := ./server/generated/webui
+UI_OUT := ./server/generated/ui
 
 ##### Build #####
-build: clean build-webui build-grpc build-swaggerui build-server
+build: clean build-ui build-grpc build-swaggerui build-server
 
-build-webui:
-	(cd webui && yarn build)
-	mkdir -p $(WEBUI_OUT)
-	mv webui/build/* $(WEBUI_OUT)
+build-ui:
+	(cd ui && npm run build:local)
+	mkdir -p $(UI_OUT)
+	mv ui/build-local/* $(UI_OUT)
 
 build-swaggerui:
 	mkdir -p $(SWAGGERUI_OUT)
@@ -62,10 +62,10 @@ build-grpc:
 
 clean:
 	rm -rf ./server/generated
-	(cd webui && rm -rf ./build)
+	(cd ui && rm -rf ./build-local ./build-cloud)
 
 ##### Install dependencies #####
-install: install-utils install-webui
+install: install-submodules install-utils install-ui
 
 install-utils:
 	go get \
@@ -73,5 +73,9 @@ install-utils:
 		github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
 		github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
 
-install-webui:
-	(cd webui && yarn install)
+install-submodules:
+	printf $(COLOR) "fetching submudules..."
+	git submodule update --init
+
+install-ui:
+	(cd ui && npm install)

--- a/server/routes/api.go
+++ b/server/routes/api.go
@@ -39,7 +39,7 @@ import (
 // SetAPIRoutes sets api routes
 func SetAPIRoutes(e *echo.Echo, temporalConn *grpc.ClientConn) error {
 	api := e.Group("/api")
-	api.GET("/me", getCurrentUser)
+	api.GET("/v1/me", getCurrentUser)
 	api.GET("/*", temporalAPIHandler(temporalConn))
 
 	return nil

--- a/server/routes/ui.go
+++ b/server/routes/ui.go
@@ -23,7 +23,6 @@
 package routes
 
 import (
-	"bytes"
 	"embed"
 	"io/fs"
 	"net/http"
@@ -31,28 +30,15 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// SetAPIRoutes sets api routes
-func SetWebUIRoutes(e *echo.Echo, indexHTML []byte, assets embed.FS) {
-	assetsHandler := buildWebUIAssetsHander(assets)
-	e.GET("/static/*", assetsHandler)
-	e.GET("/favicon.ico", assetsHandler)
-	e.GET("/manifest.json", assetsHandler)
-	e.GET("/asset-manifest.json", assetsHandler)
-	e.GET("/logo192.png", assetsHandler)
-	e.GET("/logo512.png", assetsHandler)
-	e.GET("/robots.txt", assetsHandler)
-	e.GET("/*", buildWebUIHander(indexHTML))
+// SetUIRoutes sets UI routes
+func SetUIRoutes(e *echo.Echo, assets embed.FS) {
+	assetsHandler := buildAssetsHander(assets)
+	e.GET("/*", assetsHandler)
 }
 
-func buildWebUIHander(indexHTML []byte) echo.HandlerFunc {
-	return func(c echo.Context) (err error) {
-		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTML))
-	}
-}
-
-func buildWebUIAssetsHander(assets embed.FS) echo.HandlerFunc {
+func buildAssetsHander(assets embed.FS) echo.HandlerFunc {
 	stream := fs.FS(assets)
-	stream, _ = fs.Sub(stream, "generated/webui")
+	stream, _ = fs.Sub(stream, "generated/ui")
 	handler := http.FileServer(http.FS(stream))
 	return echo.WrapHandler(handler)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -39,11 +39,8 @@ import (
 	"github.com/temporalio/web-go/server/server_options"
 )
 
-//go:embed generated/webui/index.html
-var webuiHTML []byte
-
-//go:embed generated/webui
-var webuiAssets embed.FS
+//go:embed generated/ui
+var uiAssets embed.FS
 
 //go:embed generated/swagger-ui/index.html
 var swaggeruiHTML []byte
@@ -84,7 +81,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	routes.SetAPIRoutes(e, conn)
 	routes.SetAuthRoutes(e, &serverOpts.Config.Auth)
 	routes.SetSwaggerUIRoutes(e, swaggeruiHTML, swaggeruiAssets)
-	routes.SetWebUIRoutes(e, webuiHTML, webuiAssets)
+	routes.SetUIRoutes(e, uiAssets)
 
 	s := &Server{
 		httpServer:   e,
@@ -94,17 +91,17 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	return s
 }
 
-// Start web ui server.
+// Start UI server.
 func (s *Server) Start() error {
-	fmt.Println("Starting web server...")
+	fmt.Println("Starting UI server...")
 	port := s.options.Config.Port
 	s.httpServer.Logger.Fatal(s.httpServer.Start(":" + strconv.Itoa(port)))
 	return nil
 }
 
-// Stop web ui server.
+// Stop UI server.
 func (s *Server) Stop() {
-	fmt.Println("Stopping web server...")
+	fmt.Println("Stopping UI server...")
 	if err := s.httpServer.Close(); err != nil {
 		s.httpServer.Logger.Warn(err)
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Switched to serving `temporalio/ui` instead of poc react app 

**NOTE**:  Dealing with an issue where `go:embed` doesn't support embedding folders/files that start with `_` and `.` . This results in contents of `_app` folder not loading (js and css)

There is an accepted proposal that should address this https://github.com/golang/go/issues/43854#issuecomment-819722769
The proposal is still open

There is also a change proposed from Svelte Kit side to address this issue
https://github.com/sveltejs/kit/pull/1370#issuecomment-853306453

## Why?
<!-- Tell your future self why have you made these changes -->
OSS serving of UI
Allows to use Session with AuthN in UI

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran the app:

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
