### PR TITLE
Serve UI as a SPA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
       - name: build
         run: make install build
       - name: test

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build-grpc:
 	mv -f $(PROTO_OUT)/temporal/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
 
 ##### Install dependencies #####
-install: install-submodules install-utils
+install: install-submodules install-utils install-ui
 
 install-utils:
 	go get \

--- a/server/routes/swaggerui.go
+++ b/server/routes/swaggerui.go
@@ -33,12 +33,11 @@ import (
 
 // SetAPIRoutes sets api routes
 func SetSwaggerUIRoutes(e *echo.Echo, indexHTML []byte, assets embed.FS) {
-	assetsHandler := buildSwaggerUIAssetsHander(assets)
-	e.GET("/swagger-ui", buildSwaggerUIHander(indexHTML))
-	e.GET("/swagger-ui/*", assetsHandler)
+	e.GET("/swagger-ui", buildSwaggerUIHandler(indexHTML))
+	e.GET("/swagger-ui/*", buildSwaggerUIAssetsHander(assets))
 }
 
-func buildSwaggerUIHander(indexHTML []byte) echo.HandlerFunc {
+func buildSwaggerUIHandler(indexHTML []byte) echo.HandlerFunc {
 	return func(c echo.Context) (err error) {
 		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTML))
 	}

--- a/server/routes/ui.go
+++ b/server/routes/ui.go
@@ -23,6 +23,7 @@
 package routes
 
 import (
+	"bytes"
 	"embed"
 	"io/fs"
 	"net/http"
@@ -31,12 +32,27 @@ import (
 )
 
 // SetUIRoutes sets UI routes
-func SetUIRoutes(e *echo.Echo, assets embed.FS) {
-	assetsHandler := buildAssetsHander(assets)
-	e.GET("/*", assetsHandler)
+func SetUIRoutes(e *echo.Echo, indexHTML []byte, assets embed.FS) {
+	assetsHandler := buildUIAssetsHander(assets)
+	e.GET("/_app/*", assetsHandler)
+	e.GET("/css/*", assetsHandler)
+	e.GET("/prism/*", assetsHandler)
+	e.GET("/android*", assetsHandler)
+	e.GET("/apple*", assetsHandler)
+	e.GET("/banner.png", assetsHandler)
+	e.GET("/favicon*", assetsHandler)
+	e.GET("/logo*", assetsHandler)
+	e.GET("/site.webmanifest", assetsHandler)
+	e.GET("/*", buildUIIndexHandler(indexHTML))
 }
 
-func buildAssetsHander(assets embed.FS) echo.HandlerFunc {
+func buildUIIndexHandler(indexHTML []byte) echo.HandlerFunc {
+	return func(c echo.Context) (err error) {
+		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTML))
+	}
+}
+
+func buildUIAssetsHander(assets embed.FS) echo.HandlerFunc {
 	stream := fs.FS(assets)
 	stream, _ = fs.Sub(stream, "generated/ui")
 	handler := http.FileServer(http.FS(stream))

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,9 @@ import (
 	"github.com/temporalio/web-go/server/server_options"
 )
 
+//go:embed generated/ui/index.html
+var uiHTML []byte
+
 // TODO resolving one of these two issues may allow to clean the embed string
 // https://github.com/golang/go/issues/43854
 // https://github.com/sveltejs/kit/pull/1370#issuecomment-853306453
@@ -84,7 +87,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	routes.SetAPIRoutes(e, conn)
 	routes.SetAuthRoutes(e, &serverOpts.Config.Auth)
 	routes.SetSwaggerUIRoutes(e, swaggeruiHTML, swaggeruiAssets)
-	routes.SetUIRoutes(e, uiAssets)
+	routes.SetUIRoutes(e, uiHTML, uiAssets)
 
 	s := &Server{
 		httpServer:   e,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Switch to serving UI as a SPA

## Why?
<!-- Tell your future self why have you made these changes -->

Fixes routing when opening the UI from sub-paths

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

* open http://localhost:8080/namespaces/default/workflows
* verify it opens correctly and data is loading

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
