### PR TITLE
Add CORS configuration

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,5 +1,8 @@
 enableUi: true
 enableOpenApi: true
+cors:
+  allowOrigins:
+    - http://localhost:3000
 auth:
   enabled: false
   providers:

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,5 +30,6 @@ docker run \
     -e TEMPORAL_AUTH_CALLBACK_URL=https://xxxx.com:8080/auth/sso/callback \ -- Auth callback url
     -e TEMPORAL_ENABLE_UI=true \                                            -- Serve UI
     -e TEMPORAL_ENABLE_OPENAPI=true \                                       -- Serve Open API UI
+    -e TEMPORAL_CORS_ORIGINS=http://localhost:3000 \                        -- Allow CORS origins
     temporalio/ui:<tag>
 ```

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -3,6 +3,10 @@ port: {{ default .Env.TEMPORAL_UI_PORT "8080" }}
 uiRootPath: {{ default .Env.TEMPORAL_UI_ROOT_PATH "/" }}
 enableUi: {{ default .Env.TEMPORAL_ENABLE_UI "true" }}
 enableOpenApi: {{ default .Env.TEMPORAL_ENABLE_OPENAPI "true" }}
+cors:
+  allowOrigins:
+    # override framework's default that allows all origins "*"
+    - {{ default .Env.TEMPORAL_CORS_ORIGINS "http://localhost:8080" }}
 auth:
     enabled: {{ default .Env.TEMPORAL_AUTH_ENABLED "false" }}
     providers:

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -37,6 +37,11 @@ type (
 		Auth                Auth   `yaml:"auth"`
 		EnableUI            bool   `yaml:"enableUi"`
 		EnableOpenAPI       bool   `yaml:"enableOpenApi"`
+		CORS                CORS   `yaml:"cors"`
+	}
+
+	CORS struct {
+		AllowOrigins []string `yaml:"allowOrigins"`
 	}
 
 	Auth struct {

--- a/server/server.go
+++ b/server/server.go
@@ -73,7 +73,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins: []string{"http://localhost:3000", "https://localhost:3000", "http://localhost:8080"},
+		AllowOrigins: serverOpts.Config.CORS.AllowOrigins,
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
 	}))
 	e.Use(session.Middleware(sessions.NewCookieStore(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds CORS configuration:

dockerize variable `TEMPORAL_CORS_ORIGINS` (or directly through the config file)

- default is http://localhost:$TEMPORAL_UI_PORT`
- `development` mode also white lists http://localhost:3000 through `development.yaml`

## Why?
<!-- Tell your future self why have you made these changes -->

- Allows to set up other CORS origins instead of hardcoded localhost:3000  

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

`docker run --network host -e TEMPORAL_CORS_ORIGINS=http://localhost:3000 temporaliotest/ui`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Updated docker README