### PR TITLE
Rename UI and OPENAPI dockerize variables

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -28,8 +28,8 @@ docker run \
     -e TEMPORAL_AUTH_CLIENT_ID=xxxxx-xxxx.apps.googleusercontent.com \      -- Auth client ID
     -e TEMPORAL_AUTH_CLIENT_SECRET=xxxxxxxxxxxxxxx \                        -- Auth client secret
     -e TEMPORAL_AUTH_CALLBACK_URL=https://xxxx.com:8080/auth/sso/callback \ -- Auth callback url
-    -e TEMPORAL_ENABLE_UI=true \                                            -- Serve UI
-    -e TEMPORAL_ENABLE_OPENAPI=true \                                       -- Serve Open API UI
+    -e TEMPORAL_UI_ENABLED=true \                                           -- Serve UI
+    -e TEMPORAL_OPENAPI_ENABLED=true \                                      -- Serve Open API UI
     -e TEMPORAL_CORS_ORIGINS=http://localhost:3000 \                        -- Allow CORS origins
     temporalio/ui:<tag>
 ```

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -1,8 +1,8 @@
 temporalGrpcAddress: {{ default .Env.TEMPORAL_ADDRESS "127.0.0.1:7233" }}
 port: {{ default .Env.TEMPORAL_UI_PORT "8080" }}
 uiRootPath: {{ default .Env.TEMPORAL_UI_ROOT_PATH "/" }}
-enableUi: {{ default .Env.TEMPORAL_ENABLE_UI "true" }}
-enableOpenApi: {{ default .Env.TEMPORAL_ENABLE_OPENAPI "true" }}
+enableUi: {{ default .Env.TEMPORAL_UI_ENABLED "true" }}
+enableOpenApi: {{ default .Env.TEMPORAL_OPENAPI_ENABLED "true" }}
 cors:
   allowOrigins:
     # override framework's default that allows all origins "*"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Changes dockers variable names from
`TEMPORAL_ENABLE_UI` -> `TEMPORAL_UI_ENABLED`
`TEMPORAL_ENABLE_OPENAPI` -> `TEMPORAL_OPENAPI_ENABLED`

## Why?
<!-- Tell your future self why have you made these changes -->

consistency with `TEMPORAL_AUTH_ENABLED` and temporal server variables

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
