### PR TITLE
Make host configurable

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -32,6 +32,7 @@ type (
 	// Config contains the configuration for the UI server
 	Config struct {
 		TemporalGRPCAddress string `yaml:"temporalGrpcAddress"`
+		Host                string `yaml:"host"`
 		Port                int    `yaml:"port"`
 		UIRootPath          string `yaml:"uiRootPath"`
 		Auth                Auth   `yaml:"auth"`

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,6 @@ package server
 import (
 	"embed"
 	"fmt"
-	"strconv"
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
@@ -103,8 +102,8 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 // Start UI server.
 func (s *Server) Start() error {
 	fmt.Println("Starting UI server...")
-	port := s.options.Config.Port
-	s.httpServer.Logger.Fatal(s.httpServer.Start(":" + strconv.Itoa(port)))
+	address := fmt.Sprintf("%s:%d", s.options.Config.Host, s.options.Config.Port)
+	s.httpServer.Logger.Fatal(s.httpServer.Start(address))
 	return nil
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This PR enables optional binding to an IP address or host name.

## Why?
<!-- Tell your future self why have you made these changes -->

I'd like to be able to listen on the loopback interface in Temporalite so that users don't get the `Do you want the application “temporalite” to accept incoming network connections?` alert every time they start the server.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

N/A

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Verified no behavior changes via `go run ./cmd/server`. Tested setting the host option via Temporalite.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No probably not. We might consider adding this as a `./cmd/server` CLI option though.