### PR TITLE
Set auth cookie for all allowed origins

### DIFF
--- a/server/routes/auth.go
+++ b/server/routes/auth.go
@@ -112,6 +112,8 @@ func authenticateCb(ctx context.Context, config *oauth2.Config, provider *oidc.P
 			Path:     "/",
 			MaxAge:   7 * 24 * int(time.Hour.Seconds()),
 			HttpOnly: true,
+			SameSite: http.SameSiteNoneMode,
+			Secure:   true,
 		}
 		sess.Values["access-token"] = &user.OAuth2Token.AccessToken
 		sess.Values["email"] = &user.IDToken.Email

--- a/server/server.go
+++ b/server/server.go
@@ -72,8 +72,9 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins: serverOpts.Config.CORS.AllowOrigins,
-		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
+		AllowOrigins:     serverOpts.Config.CORS.AllowOrigins,
+		AllowHeaders:     []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
+		AllowCredentials: true,
 	}))
 	e.Use(session.Middleware(sessions.NewCookieStore(
 		securecookie.GenerateRandomKey(32),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Sets cookies for UI that is also served from a different & allowed origin 

## Why?
<!-- Tell your future self why have you made these changes -->

Making auth work with UI served from different origin

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

* Start the ui-server and UI under different origins (ports work too)
* Configure auth through development.yaml file
* Navigate to UI and follow auth flow
* Verify that `auth` cookie is set in browser dev tools

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
