### PR TITLE
Support mTLS connection to Temporal server

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -18,3 +18,9 @@ auth:
       audience:
       callbackUrl: http://localhost:8080/auth/sso/callback
       passIdToken: false
+tls:
+  сaFile: ""
+  certFile: ""
+  keyFile: ""
+  enableHostVerification: "false"
+  serverName: tls-server

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,5 +31,10 @@ docker run \
     -e TEMPORAL_UI_ENABLED=true \                                           -- Serve UI
     -e TEMPORAL_OPENAPI_ENABLED=true \                                      -- Serve Open API UI
     -e TEMPORAL_CORS_ORIGINS=http://localhost:3000 \                        -- Allow CORS origins
+    -e TEMPORAL_TLS_CA=../ca.cert                                           -- TLS Certificate Authority path
+    -e TEMPORAL_TLS_CERT=../cluster.pem                                     -- TLS cert path
+    -e TEMPORAL_TLS_KEY=../cluster.key                                      -- TLS key path
+    -e TEMPORAL_TLS_ENABLE_HOST_VERIFICATION=true                           -- TLS enable host verification
+    -e TEMPORAL_TLS_SERVER_NAME=tls-server                                  -- TLS server name
     temporalio/ui:<tag>
 ```

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -7,6 +7,12 @@ cors:
   allowOrigins:
     # override framework's default that allows all origins "*"
     - {{ default .Env.TEMPORAL_CORS_ORIGINS "http://localhost:8080" }}
+tls:
+  сaFile: {{ default .Env.TEMPORAL_TLS_CA "" }}
+  certFile: {{ default .Env.TEMPORAL_TLS_CERT "" }}
+  keyFile: {{ default .Env.TEMPORAL_TLS_KEY "" }}
+  enableHostVerification: {{ default .Env.TEMPORAL_TLS_ENABLE_HOST_VERIFICATION "false" }}
+  serverName: {{ default .Env.TEMPORAL_TLS_SERVER_NAME "" }}
 auth:
     enabled: {{ default .Env.TEMPORAL_AUTH_ENABLED "false" }}
     providers:

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -35,6 +35,7 @@ type (
 		Host                string `yaml:"host"`
 		Port                int    `yaml:"port"`
 		UIRootPath          string `yaml:"uiRootPath"`
+		TLS                 TLS    `yaml:"tls"`
 		Auth                Auth   `yaml:"auth"`
 		EnableUI            bool   `yaml:"enableUi"`
 		EnableOpenAPI       bool   `yaml:"enableOpenApi"`
@@ -43,6 +44,14 @@ type (
 
 	CORS struct {
 		AllowOrigins []string `yaml:"allowOrigins"`
+	}
+
+	TLS struct {
+		CaFile                 string `yaml:"сaFile"`
+		CertFile               string `yaml:"certFile"`
+		KeyFile                string `yaml:"keyFile"`
+		EnableHostVerification bool   `yaml:"enableHostVerification"`
+		ServerName             string `yaml:"serverName"`
 	}
 
 	Auth struct {

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -47,9 +47,8 @@ const (
 )
 
 // CreateFrontendGRPCConnection creates connection for gRPC calls
-func CreateFrontendGRPCConnection(hostName string) *grpc.ClientConn {
-	var tlsClientConfig *tls.Config
-	connection, err := Dial(hostName, tlsClientConfig)
+func CreateFrontendGRPCConnection(hostName string, tls *tls.Config) *grpc.ClientConn {
+	connection, err := Dial(hostName, tls)
 
 	if err != nil {
 		fmt.Println("Failed to create gRPC connection")

--- a/server/rpc/tls.go
+++ b/server/rpc/tls.go
@@ -1,0 +1,153 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/temporalio/ui-server/server/config"
+)
+
+const (
+	localHostPort = "127.0.0.1:7233"
+)
+
+var netClient HttpGetter = &http.Client{
+	Timeout: time.Second * 10,
+}
+
+type HttpGetter interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
+func CreateTLSConfig(address string, cfg config.TLS, logger echo.Logger) (*tls.Config, error) {
+	var host string
+	var cert *tls.Certificate
+	var caPool *x509.CertPool
+
+	if cfg.CaFile != "" {
+		caCertPool, err := fetchCACert(cfg.CaFile)
+		if err != nil {
+			logger.Fatalf("Unable to load server CA certificate")
+			return nil, err
+		}
+		caPool = caCertPool
+	}
+	if cfg.CertFile != "" {
+		myCert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			logger.Fatalf("Unable to load client certificate")
+			return nil, err
+		}
+		cert = &myCert
+	}
+	// If we are given arguments to verify either server or client, configure TLS
+	if caPool != nil || cert != nil {
+		if cfg.ServerName != "" {
+			host = cfg.ServerName
+		} else {
+			hostPort := address
+			if hostPort == "" {
+				hostPort = localHostPort
+			}
+			// Ignoring error as we'll fail to dial anyway, and that will produce a meaningful error
+			host, _, _ = net.SplitHostPort(hostPort)
+		}
+		tlsConfig := NewTLSConfigForServer(host, cfg.EnableHostVerification)
+		if caPool != nil {
+			tlsConfig.RootCAs = caPool
+		}
+		if cert != nil {
+			tlsConfig.Certificates = []tls.Certificate{*cert}
+		}
+
+		return tlsConfig, nil
+	}
+	// If we are given a server name, set the TLS server name for DNS resolution
+	if cfg.ServerName != "" {
+		host = cfg.ServerName
+		tlsConfig := NewTLSConfigForServer(host, cfg.EnableHostVerification)
+		return tlsConfig, nil
+	}
+
+	return nil, nil
+}
+
+func fetchCACert(pathOrUrl string) (caPool *x509.CertPool, err error) {
+	caPool = x509.NewCertPool()
+	var caBytes []byte
+
+	if strings.HasPrefix(pathOrUrl, "http://") {
+		return nil, errors.New("HTTP is not supported for CA cert URLs. Provide HTTPS URL")
+	}
+
+	if strings.HasPrefix(pathOrUrl, "https://") {
+		resp, err := netClient.Get(pathOrUrl)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		caBytes, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		caBytes, err = os.ReadFile(pathOrUrl)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !caPool.AppendCertsFromPEM(caBytes) {
+		return nil, errors.New("unknown failure constructing cert pool for ca")
+	}
+	return caPool, nil
+}
+
+func NewEmptyTLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{
+			"h2",
+		},
+	}
+}
+
+func NewTLSConfigForServer(
+	serverName string,
+	enableHostVerification bool,
+) *tls.Config {
+	c := NewEmptyTLSConfig()
+	c.ServerName = serverName
+	c.InsecureSkipVerify = !enableHostVerification
+	return c
+}

--- a/server/server.go
+++ b/server/server.go
@@ -88,7 +88,8 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		securecookie.GenerateRandomKey(32),
 	)))
 
-	conn := rpc.CreateFrontendGRPCConnection(serverOpts.Config.TemporalGRPCAddress)
+	tlsCfg, _ := rpc.CreateTLSConfig(serverOpts.Config.TemporalGRPCAddress, serverOpts.Config.TLS, e.Logger)
+	conn := rpc.CreateFrontendGRPCConnection(serverOpts.Config.TemporalGRPCAddress, tlsCfg)
 	routes.SetAPIRoutes(e, serverOpts.Config, conn)
 
 	routes.SetAuthRoutes(e, &serverOpts.Config.Auth)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds support for mTLS

## Why?
<!-- Tell your future self why have you made these changes -->

Allows communicating with secured Temporal server

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

1. Run Temporal server with mTLS not set. Run ui-server and verify that namespaces and other data is loaded

2. Run secured Temporal server using https://github.com/temporalio/samples-server/tree/main/tls/tls-simple
  - set TLS config in development.yaml
``` yaml
tls:
  сaFile: /home/USERNAME/samples-server/tls/tls-simple/certs/ca.cert
  certFile: /home/USERNAME/samples-server/tls/tls-simple/certs/cluster.pem
  keyFile: /home/USERNAME/samples-server/tls/tls-simple/certs/cluster.key
  enableHostVerification: true
  serverName: tls-sample
```
  - verify namespaces and other data calls succeed
 
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
