### PR TITLE
Support TLS config as base64 values

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -22,5 +22,8 @@ tls:
   caFile:
   certFile:
   keyFile:
+  caData:
+  certData:
+  keyData:
   enableHostVerification: false
   serverName:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -8,9 +8,12 @@ cors:
     # override framework's default that allows all origins "*"
     - {{ default .Env.TEMPORAL_CORS_ORIGINS "http://localhost:8080" }}
 tls:
-  сaFile: {{ default .Env.TEMPORAL_TLS_CA "" }}
+  caFile: {{ default .Env.TEMPORAL_TLS_CA "" }}
   certFile: {{ default .Env.TEMPORAL_TLS_CERT "" }}
   keyFile: {{ default .Env.TEMPORAL_TLS_KEY "" }}
+  caData: {{ default .Env.TEMPORAL_TLS_CA_DATA "" }}
+  certData: {{ default .Env.TEMPORAL_TLS_CERT_DATA "" }}
+  keyData: {{ default .Env.TEMPORAL_TLS_KEY_DATA "" }}
   enableHostVerification: {{ default .Env.TEMPORAL_TLS_ENABLE_HOST_VERIFICATION "false" }}
   serverName: {{ default .Env.TEMPORAL_TLS_SERVER_NAME "" }}
 auth:

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -47,9 +47,12 @@ type (
 	}
 
 	TLS struct {
-		CaFile                 string `yaml:"сaFile"`
+		CaFile                 string `yaml:"caFile"`
 		CertFile               string `yaml:"certFile"`
 		KeyFile                string `yaml:"keyFile"`
+		CaData                 string `yaml:"caData"`
+		CertData               string `yaml:"certData"`
+		KeyData                string `yaml:"keyData"`
 		EnableHostVerification bool   `yaml:"enableHostVerification"`
 		ServerName             string `yaml:"serverName"`
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -25,6 +25,7 @@ package server
 import (
 	"embed"
 	"fmt"
+	"log"
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
@@ -101,7 +102,11 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		securecookie.GenerateRandomKey(32),
 	)))
 
-	tlsCfg, _ := rpc.CreateTLSConfig(serverOpts.Config.TemporalGRPCAddress, serverOpts.Config.TLS, e.Logger)
+	tlsCfg, err := rpc.CreateTLSConfig(serverOpts.Config.TemporalGRPCAddress, &serverOpts.Config.TLS)
+	if err != nil {
+		log.Printf("Unable to create TLS config: %v\n", err)
+		log.Printf("Establishing insecure connection to Temporal")
+	}
 	conn := rpc.CreateFrontendGRPCConnection(serverOpts.Config.TemporalGRPCAddress, tlsCfg)
 	routes.SetAPIRoutes(e, serverOpts.Config, conn)
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds support for TLS config to be passed directly as base64 values instead of file paths

## Why?
<!-- Tell your future self why have you made these changes -->

For users who prefer to inline TLS values in the config file rather than having separate files

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

With https://github.com/temporalio/samples-server/tree/main/tls/tls-simple
- with file paths
- with base64 values
- w/o TLS

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
