### PR TITLE
Push docker image on release, not on tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_commit.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.meta_commit.outputs.labels }}
 
       - name: Docker meta for Release image
         id: meta_release
@@ -54,7 +54,7 @@ jobs:
       - name: Push Release image to DockerHub
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'tag' }}
+          push: ${{ github.event_name == 'release' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta_release.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.meta_release.outputs.labels }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Makes the release docker image push on Release event, not tag

## Why?
<!-- Tell your future self why have you made these changes -->

correcting github release event name

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

not tested, based on docs

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
