### PR TITLE
Allow configuring default namespace for UI to navigate to

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -3,6 +3,7 @@ port: {{ default .Env.TEMPORAL_UI_PORT "8080" }}
 uiRootPath: {{ default .Env.TEMPORAL_UI_ROOT_PATH "/" }}
 enableUi: {{ default .Env.TEMPORAL_UI_ENABLED "true" }}
 enableOpenApi: {{ default .Env.TEMPORAL_OPENAPI_ENABLED "true" }}
+defaultNamespace: {{ .Env.TEMPORAL_DEFAULT_NAMESPACE }}
 cors:
   allowOrigins:
     # override framework's default that allows all origins "*"

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -40,6 +40,7 @@ type (
 		EnableUI            bool   `yaml:"enableUi"`
 		EnableOpenAPI       bool   `yaml:"enableOpenApi"`
 		CORS                CORS   `yaml:"cors"`
+		DefaultNamespace    string `yaml:"defaultNamespace"`
 	}
 
 	CORS struct {

--- a/server/routes/api.go
+++ b/server/routes/api.go
@@ -98,10 +98,12 @@ func getSettings(cfg *config.Config) func(echo.Context) error {
 			Auth struct {
 				Enabled bool
 			}
+			DefaultNamespace string
 		}{
 			struct{ Enabled bool }{
 				cfg.Auth.Enabled,
 			},
+			cfg.DefaultNamespace,
 		}
 
 		return c.JSON(http.StatusOK, settings)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allows to configure the default the namespace

## Why?
<!-- Tell your future self why have you made these changes -->

UI will navigate to that

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Add `defaultNamespace: accounting` in `development.yaml`
Open Dev tools of your browser
Verify that the `settings` response contains default namespace, ex
```
{"Auth":{"Enabled":false},"DefaultNamespace":"accounting"}
``` 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
