### PR TITLE
Avoid making Temporal API calls if user unauthenticated

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,7 @@ var uiHTML []byte
 // https://github.com/sveltejs/kit/pull/1370#issuecomment-853306453
 //go:embed generated/ui/*
 //go:embed generated/ui/_app/assets/pages/*
+//go:embed generated/ui/_app/assets/_*
 //go:embed generated/ui/_app/chunks/*
 //go:embed generated/ui/_app/pages/*
 //go:embed generated/ui/_app/assets/pages/namespaces/\[namespace\]/workflows/\[workflow\]/\[run\]/history/compact/activity-\[eventId\]/*


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

When Auth is enabled and user is unauthenticated, immediately throws unauthorized error instead of making calls to Temporal Service

## Why?
<!-- Tell your future self why have you made these changes -->

perf & security in case a TLS connection is treated as a way to avoid/not need user authentication

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
