### PR TITLE
Remove config provider interface pointer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -81,7 +81,7 @@ func buildCLI() *cli.App {
 				cfgProvider := fs_config_provider.NewFSConfigProvider(configDir, env)
 
 				s := server.NewServer(
-					server_options.WithConfigProvider(&cfgProvider),
+					server_options.WithConfigProvider(cfgProvider),
 				)
 				defer s.Stop()
 				err := s.Start()

--- a/server/server.go
+++ b/server/server.go
@@ -77,7 +77,7 @@ type (
 // NewServer returns a new instance of server that serves one or many services.
 func NewServer(opts ...server_options.ServerOption) *Server {
 	serverOpts := server_options.NewServerOptions(opts)
-	cfgProvider, err := config.NewConfigProviderWithRefresh(*serverOpts.ConfigProvider)
+	cfgProvider, err := config.NewConfigProviderWithRefresh(serverOpts.ConfigProvider)
 	if err != nil {
 		panic(err)
 	}

--- a/server/server_options/server_option.go
+++ b/server/server_options/server_option.go
@@ -35,7 +35,7 @@ type (
 )
 
 // WithConfigProvider supplies the config for the UI server
-func WithConfigProvider(cfgProvider *config.ConfigProvider) ServerOption {
+func WithConfigProvider(cfgProvider config.ConfigProvider) ServerOption {
 	return newApplyFuncContainer(func(s *ServerOptions) {
 		s.ConfigProvider = cfgProvider
 	})

--- a/server/server_options/server_options.go
+++ b/server/server_options/server_options.go
@@ -30,7 +30,7 @@ import (
 
 type (
 	ServerOptions struct {
-		ConfigProvider *config.ConfigProvider
+		ConfigProvider config.ConfigProvider
 	}
 )
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

The `WithConfigProvider` start option has been updated to accept a `ConfigProvider` argument (an interface) rather than `*ConfigProvider` (a concrete type). This is a breaking change for users of the `github.com/temporalio/ui-server/server/server_options` package.

## Why?
<!-- Tell your future self why have you made these changes -->

Pointers to interfaces can be tricky to work with; see this thread for more background: https://stackoverflow.com/questions/44370277/type-is-pointer-to-interface-not-interface-confusion

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
