### PR TITLE
Expose auth options through settings API

### DIFF
--- a/server/routes/api.go
+++ b/server/routes/api.go
@@ -118,14 +118,27 @@ func getSettings(cfgProvier *config.ConfigProviderWithRefresh) func(echo.Context
 			return c.JSON(http.StatusInternalServerError, err)
 		}
 
+		var options []string
+		if len(cfg.Auth.Providers) != 0 {
+			authProviderCfg := cfg.Auth.Providers[0].Options
+			for k := range authProviderCfg {
+				options = append(options, k)
+			}
+		}
+
 		settings := struct {
 			Auth struct {
 				Enabled bool
+				Options []string
 			}
 			DefaultNamespace string
 		}{
-			struct{ Enabled bool }{
+			struct {
+				Enabled bool
+				Options []string
+			}{
 				cfg.Auth.Enabled,
+				options,
 			},
 			cfg.DefaultNamespace,
 		}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Exposes auth options names from the config, 

For example the auth config may have entries
 - organization
 - invitation
 - audience
... to support invitation flow in case of Auth0

## Why?
<!-- Tell your future self why have you made these changes -->

Let's UI know what additional options your auth flow expects

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
