### PR TITLE
Set dockerize default namespace

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -3,7 +3,7 @@ port: {{ default .Env.TEMPORAL_UI_PORT "8080" }}
 uiRootPath: {{ default .Env.TEMPORAL_UI_ROOT_PATH "/" }}
 enableUi: {{ default .Env.TEMPORAL_UI_ENABLED "true" }}
 enableOpenApi: {{ default .Env.TEMPORAL_OPENAPI_ENABLED "true" }}
-defaultNamespace: {{ .Env.TEMPORAL_DEFAULT_NAMESPACE }}
+defaultNamespace: {{ default .Env.TEMPORAL_DEFAULT_NAMESPACE "default" }}
 refreshInterval: {{ default .Env.TEMPORAL_CONFIG_REFRESH_INTERVAL "0s" }}
 cors:
   allowOrigins:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Sets a default namespace when using docker image

## Why?
<!-- Tell your future self why have you made these changes -->

Unless users would pass a `TEMPORAL_DEFAULT_NAMESPACE` when starting a docker image, UI would try to navigate by default to `<no value>` namespace 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

build & start the docker image
open http://localhost:8080/

expected: should navigate to http://localhost:8080/namespaces/default

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
