### PR TITLE
Increase gRPC receive max message size to 64mb

### DIFF
--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -79,6 +79,9 @@ func Dial(hostName string, tlsConfig *tls.Config) (*grpc.ClientConn, error) {
 	}
 	cp.Backoff.MaxDelay = MaxBackoffDelay
 
+	mb := 1024 * 1024
+	maxPayloadSize := 64 * mb
+
 	return grpc.Dial(hostName,
 		grpcSecureOpt,
 		grpc.WithChainUnaryInterceptor(
@@ -86,6 +89,7 @@ func Dial(hostName string, tlsConfig *tls.Config) (*grpc.ClientConn, error) {
 		grpc.WithDefaultServiceConfig(DefaultServiceConfig),
 		grpc.WithDisableServiceConfig(),
 		grpc.WithConnectParams(cp),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxPayloadSize)),
 	)
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Incrased max gRPC API response size to 64mb

## Why?
<!-- Tell your future self why have you made these changes -->

addressed #121

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Created a payload of 28mb size using https://github.com/temporalio/samples-go/tree/main/temporal-fixtures/largepayload

Verified that the page doesn't throw 429, also under ~4mb/s network: 
![image](https://user-images.githubusercontent.com/11838981/162345728-a12a6b7d-8f7a-47f7-90e2-5e9fa451f09f.png)


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
