### PR TITLE
Allow customizing Feedback URL

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -6,6 +6,7 @@ cors:
 refreshInterval: 1m
 defaultNamespace: default
 showTemporalSystemNamespace: false
+feedbackUrl:
 auth:
   enabled: false
   providers:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -4,6 +4,7 @@ uiRootPath: {{ default .Env.TEMPORAL_UI_ROOT_PATH "/" }}
 enableUi: {{ default .Env.TEMPORAL_UI_ENABLED "true" }}
 enableOpenApi: {{ default .Env.TEMPORAL_OPENAPI_ENABLED "true" }}
 defaultNamespace: {{ default .Env.TEMPORAL_DEFAULT_NAMESPACE "default" }}
+feedbackUrl: {{ default .Env.TEMPORAL_FEEDBACK_URL "" }}
 refreshInterval: {{ default .Env.TEMPORAL_CONFIG_REFRESH_INTERVAL "0s" }}
 showTemporalSystemNamespace:
   {{ default .Env.TEMPORAL_SHOW_TEMPORAL_SYSTEM_NAMESPACE "false" }}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -42,6 +42,7 @@ type (
 		EnableOpenAPI       bool   `yaml:"enableOpenApi"`
 		CORS                CORS   `yaml:"cors"`
 		DefaultNamespace    string `yaml:"defaultNamespace"`
+		FeedbackURL         string `yaml:"feedbackUrl"`
 		// show temporal-system namespace in namespace selector
 		ShowTemporalSystemNamespace bool `yaml:"showTemporalSystemNamespace"`
 		// How often to reload the config

--- a/server/routes/api.go
+++ b/server/routes/api.go
@@ -39,6 +39,24 @@ import (
 	"github.com/temporalio/ui-server/server/rpc"
 )
 
+type Auth struct {
+	Enabled bool
+	Options []string
+}
+
+type Codec struct {
+	Endpoint        string
+	PassAccessToken bool
+}
+
+type SettingsResponse struct {
+	Auth                        *Auth
+	DefaultNamespace            string
+	ShowTemporalSystemNamespace bool
+	FeedbackURL                 string
+	Codec                       *Codec
+}
+
 // SetAPIRoutes sets api routes
 func SetAPIRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) error {
 	api := e.Group("/api")
@@ -126,33 +144,17 @@ func getSettings(cfgProvier *config.ConfigProviderWithRefresh) func(echo.Context
 			}
 		}
 
-		settings := struct {
-			Auth struct {
-				Enabled bool
-				Options []string
-			}
-			DefaultNamespace            string
-			ShowTemporalSystemNamespace bool
-			Codec struct {
-				Endpoint         string
-				PassAccessToken  bool		
-			}
-		}{
-			struct {
-				Enabled bool
-				Options []string
-			}{
-				cfg.Auth.Enabled,
-				options,
+		settings := &SettingsResponse{
+			Auth: &Auth{
+				Enabled: cfg.Auth.Enabled,
+				Options: options,
 			},
-			cfg.DefaultNamespace,
-			cfg.ShowTemporalSystemNamespace,
-			struct {
-				Endpoint         string
-				PassAccessToken  bool		
-			}{
-				cfg.Codec.Endpoint,
-				cfg.Codec.PassAccessToken,
+			DefaultNamespace:            cfg.DefaultNamespace,
+			ShowTemporalSystemNamespace: cfg.ShowTemporalSystemNamespace,
+			FeedbackURL:                 cfg.FeedbackURL,
+			Codec: &Codec{
+				Endpoint:        cfg.Codec.Endpoint,
+				PassAccessToken: cfg.Codec.PassAccessToken,
 			},
 		}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds config option for Feedback URL

## Why?
<!-- Tell your future self why have you made these changes -->

Allows to change Feedback button URL so that users can point to their internal channels
Partially addresses https://github.com/temporalio/ui/issues/502

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

http://localhost:8080/api/v1/settings
```
{"Auth":{"Enabled":false,"Options":{
  "Auth": {
    "Enabled": false,
    "Options": ["invitation", "audience", "organization"]
  },
  "DefaultNamespace": "default",
  "ShowTemporalSystemNamespace": false,
  "FeedbackURL": "https://custom-feedback-url",
  "Codec": { "Endpoint": "", "PassAccessToken": false }
}

```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
