### PR TITLE
Add API to set codec endpoint

### DIFF
--- a/server/codec/codec.go
+++ b/server/codec/codec.go
@@ -1,0 +1,68 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package codec
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo-contrib/session"
+	"github.com/labstack/echo/v4"
+
+	"github.com/temporalio/ui-server/server/config"
+)
+
+const (
+	sessionKey       = "codec"
+	codecEndpointKey = "endpoint"
+)
+
+type Codec struct {
+	Endpoint        string
+	PassAccessToken bool
+}
+
+func SetCodecEndpoint(c echo.Context) error {
+	sess, _ := session.Get(sessionKey, c)
+	sess.Values[codecEndpointKey] = c.Param(codecEndpointKey)
+	sess.Save(c.Request(), c.Response())
+	return c.NoContent(http.StatusOK)
+}
+
+func GetCodec(c echo.Context, cfg *config.Config) *Codec {
+	sess, _ := session.Get(sessionKey, c)
+	sessEndpoint := sess.Values[codecEndpointKey]
+
+	var endpoint string
+	if sessEndpoint != nil && sessEndpoint.(string) != "" {
+		endpoint = sessEndpoint.(string)
+	} else {
+		endpoint = cfg.Codec.Endpoint
+	}
+
+	return &Codec{
+		Endpoint:        endpoint,
+		PassAccessToken: cfg.Codec.PassAccessToken,
+	}
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds API `http://localhost:8080/api/v1/settings/codec/:endpoint` that will overwrite Codec Endpoint set through config

## Why?
<!-- Tell your future self why have you made these changes -->

useful when testing new implementations of codec 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
 

- Set `codec endpoint` through config to any value
- Open http://localhost:8080/api/v1/settings and verify that the endpoint matches config value
- POST `http://localhost:8080/api/v1/settings/codec/:555`
- Open http://localhost:8080/api/v1/settings and verify that the endpoint has changed to 555

5. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
