### PR TITLE
Disable HTTPOnly in CSRF cookie to fix write operations

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -87,7 +87,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	e.Use(middleware.Secure())
 	e.Use(middleware.CSRFWithConfig(middleware.CSRFConfig{
 		CookiePath:     "/",
-		CookieHTTPOnly: true,
+		CookieHTTPOnly: false,
 		CookieSameSite: http.SameSiteStrictMode,
 		CookieSecure:   true,
 	}))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Disabled `HTTPOnly` in CSRF cookie 

## Why?
<!-- Tell your future self why have you made these changes -->

This rule enabled was breaking Terminate and Query functionalities as CSRF header is set via javascript on the client side

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Verified Terminate works

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
