### PR TITLE
Fix docker non root accesss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,14 @@ RUN make build-server
 FROM ${BASE_SERVER_IMAGE} AS ui-server
 WORKDIR /home/ui-server
 
+RUN addgroup -g 5000 temporal
+RUN adduser -u 5000 -G temporal -D temporal
+
 COPY --from=ui-builder /home/ui-builder/ui-server ./
 COPY docker/start-ui-server.sh ./start-ui-server.sh
 COPY docker/config_template.yaml ./config/config_template.yaml
+
+RUN chown temporal:temporal /home/ui-server -R
 
 EXPOSE 8080
 ENTRYPOINT ["./start-ui-server.sh"]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Docker non root access

## Why?
There is an issue on kubernetes when security context is set to run as non root

1. Closes  #156

2. How was this tested:
Provet docker was built and deploy on kubernetes with set security context:
securityContext:
     runAsNonRoot: true
     runAsUser: 5000
     capabilities:
        drop:
           - all


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
There need to be information that container need to be run as user 5000 on kubernetes cluster.
