### PR TITLE
Implement passing ID Token with API calls

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -77,13 +77,13 @@ func GetCurrentUser(c echo.Context) error {
 	return c.JSON(http.StatusOK, user)
 }
 
-func SetUser(c echo.Context, serverCfg *config.Config, user *User) error {
+func SetUser(c echo.Context, user *User) error {
 	err := setAccessToken(c, user.OAuth2Token.AccessToken)
 	if err != nil {
 		return err
 	}
 
-	err = setIDToken(c, serverCfg, user.IDToken)
+	err = setIDToken(c, user.IDToken)
 	if err != nil {
 		return err
 	}
@@ -176,16 +176,14 @@ func getAuthorizationExtras(c echo.Context) string {
 	return extras.(string)
 }
 
-func setIDToken(c echo.Context, serverCfg *config.Config, idToken *IDToken) error {
+func setIDToken(c echo.Context, idToken *IDToken) error {
 	sess, _ := session.Get(AuthExtrasCookie, c)
 	sess.Options = sessOpts
 
 	sess.Values[EmailKey] = &idToken.Claims.Email
 	sess.Values[PictureKey] = &idToken.Claims.Picture
 	sess.Values[NameKey] = &idToken.Claims.Name
-	if serverCfg.Auth.Providers[0].PassIDToken {
-		sess.Values[IDTokenKey] = &idToken.RawToken
-	}
+	sess.Values[IDTokenKey] = &idToken.RawToken
 
 	err := sess.Save(c.Request(), c.Response())
 	if err != nil {

--- a/server/auth/oidc.go
+++ b/server/auth/oidc.go
@@ -35,7 +35,12 @@ import (
 
 type User struct {
 	OAuth2Token *oauth2.Token
-	IDToken     *Claims
+	IDToken     *IDToken
+}
+
+type IDToken struct {
+	RawToken string
+	Claims   Claims
 }
 
 type Claims struct {
@@ -88,7 +93,10 @@ func ExchangeCode(ctx context.Context, r *http.Request, config *oauth2.Config, p
 
 	user := User{
 		OAuth2Token: oauth2Token,
-		IDToken:     &claims,
+		IDToken: &IDToken{
+			RawToken: rawIDToken,
+			Claims:   claims,
+		},
 	}
 
 	return &user, nil

--- a/server/routes/auth.go
+++ b/server/routes/auth.go
@@ -119,14 +119,14 @@ func authenticate(config *oauth2.Config, options map[string]interface{}) func(ec
 	}
 }
 
-func authenticateCb(ctx context.Context, serverCfg *config.Config, oauthCfg *oauth2.Config, provider *oidc.Provider) func(echo.Context) error {
+func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider) func(echo.Context) error {
 	return func(c echo.Context) error {
 		user, err := auth.ExchangeCode(ctx, c.Request(), oauthCfg, provider)
 		if err != nil {
 			return err
 		}
 
-		err = auth.SetUser(c, serverCfg, user)
+		err = auth.SetUser(c, user)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "unable to set user: "+err.Error())
 		}

--- a/server/routes/auth.go
+++ b/server/routes/auth.go
@@ -45,27 +45,27 @@ import (
 // SetAuthRoutes sets routes used by auth
 func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) {
 	ctx := context.Background()
-	cfg, err := cfgProvider.GetConfig()
+	serverCfg, err := cfgProvider.GetConfig()
 	if err != nil {
 		fmt.Printf("unable to get auth config: %s\n", err)
 	}
 
-	if !cfg.Auth.Enabled {
+	if !serverCfg.Auth.Enabled {
 		return
 	}
 
-	if len(cfg.Auth.Providers) == 0 {
+	if len(serverCfg.Auth.Providers) == 0 {
 		log.Fatal(`auth providers configuration is empty. Configure an auth provider or disable auth`)
 	}
 
-	providerCfg := cfg.Auth.Providers[0] // only single provider is currently supported
+	providerCfg := serverCfg.Auth.Providers[0] // only single provider is currently supported
 
 	provider, err := oidc.NewProvider(ctx, providerCfg.ProviderUrl)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	config := oauth2.Config{
+	oauthCfg := oauth2.Config{
 		ClientID:     providerCfg.ClientID,
 		ClientSecret: providerCfg.ClientSecret,
 		Endpoint:     provider.Endpoint(),
@@ -75,9 +75,9 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 
 	api := e.Group("/auth")
 
-	api.GET("/sso", authenticate(&config, providerCfg.Options))
-	api.GET("/sso/callback", authenticateCb(ctx, &config, provider))
-	api.GET("/sso_callback", authenticateCb(ctx, &config, provider)) // compatibility with UI v1
+	api.GET("/sso", authenticate(&oauthCfg, providerCfg.Options))
+	api.GET("/sso/callback", authenticateCb(ctx, &oauthCfg, provider))
+	api.GET("/sso_callback", authenticateCb(ctx, &oauthCfg, provider)) // compatibility with UI v1
 	api.GET("/logout", logout)
 }
 
@@ -119,14 +119,14 @@ func authenticate(config *oauth2.Config, options map[string]interface{}) func(ec
 	}
 }
 
-func authenticateCb(ctx context.Context, config *oauth2.Config, provider *oidc.Provider) func(echo.Context) error {
+func authenticateCb(ctx context.Context, serverCfg *config.Config, oauthCfg *oauth2.Config, provider *oidc.Provider) func(echo.Context) error {
 	return func(c echo.Context) error {
-		user, err := auth.ExchangeCode(ctx, c.Request(), config, provider)
+		user, err := auth.ExchangeCode(ctx, c.Request(), oauthCfg, provider)
 		if err != nil {
 			return err
 		}
 
-		err = auth.SetUser(c, user)
+		err = auth.SetUser(c, serverCfg, user)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "unable to set user: "+err.Error())
 		}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Started sending ID Token in a `authorization-extras` header  
- Slightly reduced auth cookie size

## Why?
<!-- Tell your future self why have you made these changes -->

- In some cases users have permissions set in ID token instead of the access token

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- google auth / verified both access token and ID token are sent with gRPC requests. 
- automated cloud testing tbd

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
