### PR TITLE
Add TLS support

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -132,7 +132,11 @@ func (s *Server) Start() error {
 	}
 
 	address := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-	s.httpServer.Logger.Fatal(s.httpServer.Start(address))
+	if cfg.TLS.CertFile != "" && cfg.TLS.KeyFile != "" {
+		s.httpServer.Logger.Fatal(s.httpServer.StartTLS(address, cfg.TLS.CertFile, cfg.TLS.KeyFile))
+	} else {
+		s.httpServer.Logger.Fatal(s.httpServer.Start(address))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What was changed
Added the ability to start the ui-server in TLS mode, that appears to be impossible otherwise.

## Why?
TLS is required to allow the UI to set some cookies like the csrf one.

## Checklist
How was this tested: Tested using a custom main.go file that calls the startTLS function.
