### PR TITLE
Support setting session store as plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ ui-server
 
 .vscode/*.log
 
+# session filesystem store path
+.tmp
+
 # Output of code generation tools
 third_party/OpenAPI/temporal
 

--- a/server/server.go
+++ b/server/server.go
@@ -91,10 +91,15 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		CookieSameSite: http.SameSiteStrictMode,
 		CookieSecure:   true,
 	}))
-	e.Use(session.Middleware(sessions.NewCookieStore(
-		securecookie.GenerateRandomKey(32),
-		securecookie.GenerateRandomKey(32),
-	)))
+
+	if serverOpts.SessionStore != nil {
+		e.Use(session.Middleware(serverOpts.SessionStore))
+	} else {
+		e.Use(session.Middleware(sessions.NewCookieStore(
+			securecookie.GenerateRandomKey(32),
+			securecookie.GenerateRandomKey(32),
+		)))
+	}
 
 	if err != nil {
 		panic(err)

--- a/server/server_options/server_option.go
+++ b/server/server_options/server_option.go
@@ -25,6 +25,7 @@
 package server_options
 
 import (
+	"github.com/gorilla/sessions"
 	"github.com/temporalio/ui-server/v2/server/api"
 	"github.com/temporalio/ui-server/v2/server/config"
 )
@@ -46,5 +47,12 @@ func WithConfigProvider(cfgProvider config.ConfigProvider) ServerOption {
 func WithAPIMiddleware(middleware []api.Middleware) ServerOption {
 	return newApplyFuncContainer(func(s *ServerOptions) {
 		s.APIMiddleware = middleware
+	})
+}
+
+// WithSessionStore supplies the session store for the UI server
+func WithSessionStore(store sessions.Store) ServerOption {
+	return newApplyFuncContainer(func(s *ServerOptions) {
+		s.SessionStore = store
 	})
 }

--- a/server/server_options/server_options.go
+++ b/server/server_options/server_options.go
@@ -25,6 +25,7 @@
 package server_options
 
 import (
+	"github.com/gorilla/sessions"
 	"github.com/temporalio/ui-server/v2/server/api"
 	"github.com/temporalio/ui-server/v2/server/config"
 )
@@ -33,6 +34,7 @@ type (
 	ServerOptions struct {
 		ConfigProvider config.ConfigProvider
 		APIMiddleware  []api.Middleware
+		SessionStore   sessions.Store
 	}
 )
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allows to set different session store through plugins

## Why?
<!-- Tell your future self why have you made these changes -->

Cookie store may not work due to limitation of 4096 bytes per cookie. The change allows to use different stores such as filesystem and other stores that implement github.com/gorilla/sessions store

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Ran ui-server w/o providing a plugin, verified that full `auth` and `auth-extras` tokens are stored as cookies
- Ran ui-server and provided `sessions.NewFilesystemStore` as a session store. Verified that `auth` and `auth-extras` cookies are now references to the session value. References are ~ 190-200 bytes

long term: Ideally switch the default store to GroupCache https://github.com/golang/groupcache

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
