### PR TITLE
Support filesystem based session store

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -38,3 +38,6 @@ tls:
 codec:
   endpoint:
   passAccessToken: false
+session:
+  filesystem:
+    path: # .tmp

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -39,3 +39,7 @@ auth:
 codec:
   endpoint: {{ default .Env.TEMPORAL_CODEC_ENDPOINT "" }}
   passAccessToken: {{ default .Env.TEMPORAL_CODEC_PASS_ACCESS_TOKEN "false" }}
+session:
+  filesystem:
+    # if non-empty, switches to filesystem store instead of cookie store. Increases size limit from 4K to 64K
+    path: {{ default .Env.TEMPORAL_SESSION_STORE_PATH "" }}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -49,6 +49,7 @@ type (
 		// How often to reload the config
 		RefreshInterval time.Duration `yaml:"refreshInterval"`
 		Codec           Codec         `yaml:"codec"`
+		Session         Session       `yaml:"session"`
 	}
 
 	CORS struct {
@@ -86,6 +87,14 @@ type (
 	Codec struct {
 		Endpoint        string `yaml:"endpoint"`
 		PassAccessToken bool   `yaml:"passAccessToken"`
+	}
+
+	Session struct {
+		Filesystem Filesystem `yaml:"filesystem"`
+	}
+
+	Filesystem struct {
+		Path string `yaml:"path"`
 	}
 )
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds configuration option to switch to filesystem store

## Why?
<!-- Tell your future self why have you made these changes -->

Increases session store limit from 4KB to 64KB to resolve auth issues when `access token` or `ID token` are larger than 4KB 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Verified it switches stores when providing and not providing configuration for the filesystem store
- E2E for auth  

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
