### PR TITLE
Add configuration to forward HTTP headers

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,8 +30,10 @@ import (
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
+	"github.com/temporalio/ui-server/v2/plugins/forwardheaders"
 	"github.com/temporalio/ui-server/v2/plugins/fs_config_provider"
 	"github.com/temporalio/ui-server/v2/server"
+	"github.com/temporalio/ui-server/v2/server/api"
 	"github.com/temporalio/ui-server/v2/server/server_options"
 	"github.com/temporalio/ui-server/v2/server/version"
 	"github.com/urfave/cli/v2"
@@ -91,6 +93,9 @@ func buildCLI() *cli.App {
 
 				opts := []server_options.ServerOption{
 					server_options.WithConfigProvider(cfgProvider),
+					server_options.WithAPIMiddleware([]api.Middleware{
+						forwardheaders.WithForwardHeaders(cfg.ForwardHeaders),
+					}),
 				}
 
 				if cfg.Session.Filesystem.Path != "" {

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -8,6 +8,7 @@ defaultNamespace: default
 showTemporalSystemNamespace: false
 feedbackUrl:
 notifyOnNewVersion: true
+disableWriteActions: false
 auth:
   enabled: false
   providers:
@@ -41,4 +42,5 @@ codec:
 session:
   filesystem:
     path: # .tmp
-disableWriteActions: false
+forwardHeaders: # can be used to pass additional HTTP headers from HTTP requests to Temporal gRPC backend
+  - X-Forwarded-For

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -9,6 +9,7 @@ notifyOnNewVersion: {{ default .Env.TEMPORAL_NOTIFY_ON_NEW_VERSION "true" }}
 refreshInterval: {{ default .Env.TEMPORAL_CONFIG_REFRESH_INTERVAL "0s" }}
 showTemporalSystemNamespace:
   {{ default .Env.TEMPORAL_SHOW_TEMPORAL_SYSTEM_NAMESPACE "false" }}
+disableWriteActions: {{ default .Env.TEMPORAL_DISABLE_WRITE_ACTIONS "false" }}
 cors:
   allowOrigins:
     # override framework's default that allows all origins "*"
@@ -43,4 +44,5 @@ session:
   filesystem:
     # if non-empty, switches to filesystem store instead of cookie store. Increases size limit from 4K to 64K
     path: {{ default .Env.TEMPORAL_SESSION_STORE_PATH "" }}
-disableWriteActions: {{ default .Env.TEMPORAL_DISABLE_WRITE_ACTIONS "false" }}
+forwardHeaders:
+  - {{ default .Env.TEMPORAL_FORWARD_HEADERS "" }}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -44,7 +44,7 @@ session:
   filesystem:
     # if non-empty, switches to filesystem store instead of cookie store. Increases size limit from 4K to 64K
     path: {{ default .Env.TEMPORAL_SESSION_STORE_PATH "" }}
-forwardHeaders:
+forwardHeaders: # comma separated list of headers to pass from HTTP API requests to Temporal gRPC backend
 {{ if .Env.TEMPORAL_FORWARD_HEADERS }}
 {{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
   - {{ . }}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -45,4 +45,8 @@ session:
     # if non-empty, switches to filesystem store instead of cookie store. Increases size limit from 4K to 64K
     path: {{ default .Env.TEMPORAL_SESSION_STORE_PATH "" }}
 forwardHeaders:
-  - {{ default .Env.TEMPORAL_FORWARD_HEADERS "" }}
+{{ if .Env.TEMPORAL_FORWARD_HEADERS }}
+{{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
+  - {{ . }}
+{{ end }}
+{{ end }}

--- a/plugins/forwardheaders/forwardheaders.go
+++ b/plugins/forwardheaders/forwardheaders.go
@@ -1,0 +1,50 @@
+// The MIT License
+//
+// Copyright (c) 2022 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package forwardheaders
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/labstack/echo/v4"
+	"github.com/temporalio/ui-server/v2/server/api"
+	"google.golang.org/grpc/metadata"
+)
+
+func WithForwardHeaders(headers []string) api.Middleware {
+	return func(c echo.Context) runtime.ServeMuxOption {
+		return runtime.WithMetadata(
+			func(ctx context.Context, req *http.Request) metadata.MD {
+				md := metadata.MD{}
+				for _, header := range headers {
+					if x, ok := c.Request().Header[header]; ok {
+						md.Append(header, x...)
+					}
+				}
+
+				return md
+			},
+		)
+	}
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -44,14 +44,15 @@ type (
 		DefaultNamespace    string `yaml:"defaultNamespace"`
 		FeedbackURL         string `yaml:"feedbackUrl"`
 		NotifyOnNewVersion  bool   `yaml:"notifyOnNewVersion"`
-		// show temporal-system namespace in namespace selector
+		// Show temporal-system namespace in namespace selector
 		ShowTemporalSystemNamespace bool `yaml:"showTemporalSystemNamespace"`
 		// How often to reload the config
 		RefreshInterval     time.Duration `yaml:"refreshInterval"`
 		Codec               Codec         `yaml:"codec"`
 		Session             Session       `yaml:"session"`
 		DisableWriteActions bool          `yaml:"disableWriteActions"`
-		ForwardHeaders      []string      `yaml:"forwardHeaders"`
+		// Forward specified HTTP headers from HTTP API requests to Temporal gRPC backend
+		ForwardHeaders []string `yaml:"forwardHeaders"`
 	}
 
 	CORS struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -51,6 +51,7 @@ type (
 		Codec               Codec         `yaml:"codec"`
 		Session             Session       `yaml:"session"`
 		DisableWriteActions bool          `yaml:"disableWriteActions"`
+		ForwardHeaders      []string      `yaml:"forwardHeaders"`
 	}
 
 	CORS struct {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allows to specify headers that will be passed from HTTP requests to gRPC Temporal backend

## Why?
<!-- Tell your future self why have you made these changes -->

Additional headers can be used for security and other use cases 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

tested passing
`TEMPORAL_FORWARD_HEADERS=X-Forwarded-For,X-Forwarded-Port` in docker image

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
