### PR TITLE
Add configuration to allow override the IssuerUrl

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -14,6 +14,7 @@ auth:
     - label: Auth0 oidc # for internal use; in future may expose as button text
       type: oidc # for futureproofing; only oidc is supported today
       providerUrl: https://myorg.us.auth0.com/
+      issuerUrl: "" # needed if the Issuer Url and the Provider Url are different
       clientId: xxxxxxxxxxxxxxxxxxxx
       clientSecret: xxxxxxxxxxxxxxxxxxxx
       scopes:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -28,6 +28,7 @@ auth:
   - label: {{ default .Env.TEMPORAL_AUTH_LABEL "sso" }}
     type: {{ default .Env.TEMPORAL_AUTH_TYPE "oidc" }}
     providerUrl: {{ .Env.TEMPORAL_AUTH_PROVIDER_URL }}
+    issuerUrl: {{ default .Env.TEMPORAL_AUTH_ISSUER_URL "" }}
     clientId: {{ .Env.TEMPORAL_AUTH_CLIENT_ID }}
     clientSecret: {{ .Env.TEMPORAL_AUTH_CLIENT_SECRET }}
     callbackUrl: {{ .Env.TEMPORAL_AUTH_CALLBACK_URL }}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -77,6 +77,7 @@ type (
 		Label        string                 `yaml:"label"`
 		Type         string                 `yaml:"type"`
 		ProviderUrl  string                 `yaml:"providerUrl"`
+		IssuerUrl    string                 `yaml:"issuerUrl"`
 		ClientID     string                 `yaml:"clientId"`
 		ClientSecret string                 `yaml:"clientSecret"`
 		Scopes       []string               `yaml:"scopes"`

--- a/server/routes/auth.go
+++ b/server/routes/auth.go
@@ -58,6 +58,9 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 
 	providerCfg := serverCfg.Auth.Providers[0] // only single provider is currently supported
 
+	if len(providerCfg.IssuerUrl) > 0 {
+		ctx = oidc.InsecureIssuerURLContext(ctx, providerCfg.IssuerUrl)
+	}
 	provider, err := oidc.NewProvider(ctx, providerCfg.ProviderUrl)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## What was changed
Adds config that overrides the issuerUrl  computed by the providerUrl

## Why?
In some cases, the provider URL is not the same as the issuerUrl, ie, in some multitenancy scenarios when we use FusionAuth or seems that in Azure too.

## Checklist

1. Closes #193

2. How was this tested:
Tested using our FusionAuth IDP.

3. Any docs updates needed?

