### PR TITLE
Discussion: Handle auth login errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,9 @@
       "mode": "debug",
       "program": "${workspaceFolder}/cmd/server",
       "cwd": "${workspaceFolder}",
-      "args": ["start"]
+      "args": [
+        "start"
+      ]
     }
   ]
 }

--- a/server/auth/oidc.go
+++ b/server/auth/oidc.go
@@ -50,10 +50,6 @@ type Claims struct {
 	Picture       string `json:"picture"`
 }
 
-func GetErrorDescription(c echo.Context) error {
-	return c.Redirect(http.StatusFound, "/login?error="+r.URL.Query().Get("code"))
-}
-
 func ExchangeCode(ctx context.Context, r *http.Request, config *oauth2.Config, provider *oidc.Provider) (*User, error) {
 	state, err := r.Cookie("state")
 	if err != nil {

--- a/server/auth/oidc.go
+++ b/server/auth/oidc.go
@@ -50,6 +50,10 @@ type Claims struct {
 	Picture       string `json:"picture"`
 }
 
+func GetErrorDescription(c echo.Context) error {
+	return c.Redirect(http.StatusFound, "/login?error="+r.URL.Query().Get("code"))
+}
+
 func ExchangeCode(ctx context.Context, r *http.Request, config *oauth2.Config, provider *oidc.Provider) (*User, error) {
 	state, err := r.Cookie("state")
 	if err != nil {
@@ -61,7 +65,11 @@ func ExchangeCode(ctx context.Context, r *http.Request, config *oauth2.Config, p
 
 	oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"))
 	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Unable to exchange token: "+err.Error())
+		// Return error description from Auth0 query param or static message?
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, r.URL.Query().Get("error_description"))
+
+		// Current generic error message
+		// return nil, echo.NewHTTPError(http.StatusInternalServerError, "Unable to exchange token: "+err.Error())
 	}
 
 	rawIDToken, ok := oauth2Token.Extra("id_token").(string)

--- a/server/routes/auth.go
+++ b/server/routes/auth.go
@@ -121,7 +121,9 @@ func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc
 	return func(c echo.Context) error {
 		user, err := auth.ExchangeCode(ctx, c.Request(), oauthCfg, provider)
 		if err != nil {
-			return err
+			// Redirect to login with error param to show to users
+			return c.Redirect(http.StatusSeeOther, "/login?error="+err.Error())
+			// return err
 		}
 
 		err = auth.SetUser(c, user)


### PR DESCRIPTION
## What was changed
Currently our users see a white page with JSON of a generic Auth0 error if they cannot successfully log in. To give users more context of the error and a better UI, we want to return 

I propose:

- [ ] On failure to exchange authorization code for access token, redirect user to login page
- [ ] Once returned to login page, show error_description query param provided by auth0 if provided. Otherwise provide static message.

Questions:
There are quite a few places where the exchange can fail. Specifically the one most seen is this one: https://github.com/temporalio/ui-server/blob/2a88c660de320ee73b95c253789326a3584506cc/server/auth/oidc.go#L64
Do we only want to handle that case or should we handle all 7 cases within? https://github.com/temporalio/ui-server/blob/2a88c660de320ee73b95c253789326a3584506cc/server/auth/oidc.go#L55-L86

Should we show a toast notification or similar error message of a bad query in workflows page?
