### PR TITLE
Enable authorization header as CSRF protection

### DIFF
--- a/server/csrf/skipper.go
+++ b/server/csrf/skipper.go
@@ -1,0 +1,31 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package csrf
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func SkipOnAuthorizationHeader(c echo.Context) bool {
+	return c.Request().Header.Get(echo.HeaderAuthorization) != ""
+}

--- a/server/csrf/skipper_test.go
+++ b/server/csrf/skipper_test.go
@@ -1,0 +1,62 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package csrf
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipOnAuthorizationHeader(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.GET, "/api/v1/settings", nil)
+	rec := httptest.NewRecorder()
+
+	tests := map[string]struct {
+		ctx                 echo.Context
+		authorizationHeader string
+		expected            bool
+	}{
+		"authorization empty": {
+			ctx:                 e.NewContext(req, rec),
+			authorizationHeader: "",
+			expected:            false,
+		},
+		"authorization set": {
+			ctx:                 e.NewContext(req, rec),
+			authorizationHeader: "Bearer xxx",
+			expected:            true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tt.ctx.Request().Header.Set(echo.HeaderAuthorization, tt.authorizationHeader)
+			assert.Equal(t, SkipOnAuthorizationHeader(tt.ctx), tt.expected)
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 
 	"github.com/temporalio/ui-server/v2/server/config"
+	"github.com/temporalio/ui-server/v2/server/csrf"
 	"github.com/temporalio/ui-server/v2/server/routes"
 	"github.com/temporalio/ui-server/v2/server/server_options"
 )
@@ -90,6 +91,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		CookieHTTPOnly: false,
 		CookieSameSite: http.SameSiteStrictMode,
 		CookieSecure:   true,
+		Skipper:        csrf.SkipOnAuthorizationHeader,
 	}))
 
 	if serverOpts.SessionStore != nil {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Allows HTTP requests with set `authorization` header to pass CSRF check

## Why?
<!-- Tell your future self why have you made these changes -->

In case when API is hosted under different origin from the UI the existing CSRF rules block API POST/PUT/.. insecure HTTPs methods which result in Terminate/.. buttons to not work. The change allows the requests with Authorization header set to pass the CSRF check as it still protects against CSRF

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

new unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
