### PR TITLE
Fix docker non-root access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,14 @@ RUN make build-server
 FROM ${BASE_SERVER_IMAGE} AS ui-server
 WORKDIR /home/ui-server
 
+RUN addgroup -g 5000 temporal
+RUN adduser -u 5000 -G temporal -D temporal
+
 COPY --from=ui-builder /home/ui-builder/ui-server ./
 COPY docker/start-ui-server.sh ./start-ui-server.sh
 COPY docker/config_template.yaml ./config/config_template.yaml
+
+RUN chown temporal:temporal /home/ui-server -R
 
 EXPOSE 8080
 ENTRYPOINT ["./start-ui-server.sh"]


### PR DESCRIPTION
## What was changed
Updates docker image to run as a non-root user. This PR recreates  https://github.com/temporalio/ui-server/pull/170 , which seems to have had some issues going through license validation. 

## Why?
Address a requirement to run all images as non-root in a kubernetes cluster. 

## Checklist
<!--- add/delete as needed --->

1. Closes  #156
