### PR TITLE
Support configuring UI public path

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -1,3 +1,3 @@
 temporalGrpcAddress: 127.0.0.1:7233
 port: 8080
-uiRootPath: /
+

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,3 +1,4 @@
+publicPath:
 enableUi: true
 enableOpenApi: true
 cors:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -1,6 +1,6 @@
 temporalGrpcAddress: {{ default .Env.TEMPORAL_ADDRESS "127.0.0.1:7233" }}
 port: {{ default .Env.TEMPORAL_UI_PORT "8080" }}
-uiRootPath: {{ default .Env.TEMPORAL_UI_ROOT_PATH "/" }}
+publicPath: {{ default .Env.TEMPORAL_PUBLIC_PATH "" }}
 enableUi: {{ default .Env.TEMPORAL_UI_ENABLED "true" }}
 enableOpenApi: {{ default .Env.TEMPORAL_OPENAPI_ENABLED "true" }}
 defaultNamespace: {{ default .Env.TEMPORAL_DEFAULT_NAMESPACE "default" }}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -35,7 +35,7 @@ type (
 		TemporalGRPCAddress string `yaml:"temporalGrpcAddress"`
 		Host                string `yaml:"host"`
 		Port                int    `yaml:"port"`
-		UIRootPath          string `yaml:"uiRootPath"`
+		PublicPath          string `yaml:"publicPath"`
 		TLS                 TLS    `yaml:"tls"`
 		Auth                Auth   `yaml:"auth"`
 		EnableUI            bool   `yaml:"enableUi"`

--- a/server/route/api.go
+++ b/server/route/api.go
@@ -24,7 +24,6 @@ package route
 
 import (
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 
 	"github.com/temporalio/ui-server/v2/server/api"
 	"github.com/temporalio/ui-server/v2/server/auth"
@@ -32,17 +31,8 @@ import (
 )
 
 // SetAPIRoutes sets api routes
-func SetAPIRoutes(e *echo.Group, cfgProvider *config.ConfigProviderWithRefresh, apiMiddleware []api.Middleware) error {
+func SetAPIRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh, apiMiddleware []api.Middleware) error {
 	route := e.Group("/api")
-
-	cfg, err := cfgProvider.GetConfig()
-	if err != nil {
-		return err
-	}
-	route.Use(middleware.Rewrite(map[string]string{
-		cfg.PublicPath + "/api/v1/*": "/api/v1/$1",
-	}))
-
 	route.GET("/v1/me", auth.GetCurrentUser)
 	route.GET("/v1/settings", api.GetSettings(cfgProvider))
 	route.Match([]string{"GET", "POST", "PUT", "PATCH", "DELETE"}, "/*", api.TemporalAPIHandler(cfgProvider, apiMiddleware))

--- a/server/route/auth.go
+++ b/server/route/auth.go
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package routes
+package route
 
 import (
 	"encoding/base64"
@@ -41,7 +41,7 @@ import (
 )
 
 // SetAuthRoutes sets routes used by auth
-func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) {
+func SetAuthRoutes(e *echo.Group, cfgProvider *config.ConfigProviderWithRefresh) {
 	ctx := context.Background()
 	serverCfg, err := cfgProvider.GetConfig()
 	if err != nil {

--- a/server/route/auth.go
+++ b/server/route/auth.go
@@ -41,7 +41,7 @@ import (
 )
 
 // SetAuthRoutes sets routes used by auth
-func SetAuthRoutes(e *echo.Group, cfgProvider *config.ConfigProviderWithRefresh) {
+func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) {
 	ctx := context.Background()
 	serverCfg, err := cfgProvider.GetConfig()
 	if err != nil {

--- a/server/route/health.go
+++ b/server/route/health.go
@@ -20,41 +20,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package routes
+package route
 
 import (
-	"bytes"
-	"embed"
-	"io/fs"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 )
 
-// SetUIRoutes sets UI routes
-func SetUIRoutes(e *echo.Echo, indexHTML []byte, assets embed.FS) {
-	assetsHandler := buildUIAssetsHander(assets)
-	e.GET("/_app/*", assetsHandler)
-	e.GET("/css/*", assetsHandler)
-	e.GET("/prism/*", assetsHandler)
-	e.GET("/android*", assetsHandler)
-	e.GET("/apple*", assetsHandler)
-	e.GET("/banner.png", assetsHandler)
-	e.GET("/favicon*", assetsHandler)
-	e.GET("/logo*", assetsHandler)
-	e.GET("/site.webmanifest", assetsHandler)
-	e.GET("/*", buildUIIndexHandler(indexHTML))
-}
-
-func buildUIIndexHandler(indexHTML []byte) echo.HandlerFunc {
-	return func(c echo.Context) (err error) {
-		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTML))
-	}
-}
-
-func buildUIAssetsHander(assets embed.FS) echo.HandlerFunc {
-	stream := fs.FS(assets)
-	stream, _ = fs.Sub(stream, "generated/ui")
-	handler := http.FileServer(http.FS(stream))
-	return echo.WrapHandler(handler)
+func SetHealthRoute(e *echo.Group) {
+	e.GET("/healthz", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"status": "OK"})
+	})
 }

--- a/server/route/openapi.go
+++ b/server/route/openapi.go
@@ -32,7 +32,7 @@ import (
 )
 
 // SetAPIRoutes sets api routes
-func SetSwaggerUIRoutes(e *echo.Group, indexHTML []byte, assets embed.FS) {
+func SetSwaggerUIRoutes(e *echo.Echo, indexHTML []byte, assets embed.FS) {
 	e.GET("/openapi", buildSwaggerUIHandler(indexHTML))
 	e.GET("/openapi/*", buildSwaggerUIAssetsHander(assets))
 }

--- a/server/route/public_path.go
+++ b/server/route/public_path.go
@@ -23,13 +23,12 @@
 package route
 
 import (
-	"net/http"
-
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetHealthRoute(e *echo.Echo) {
-	e.GET("/healthz", func(c echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]string{"status": "OK"})
+func PublicPath(path string) echo.MiddlewareFunc {
+	return middleware.Rewrite(map[string]string{
+		path + "/*": "/$1",
 	})
 }

--- a/server/route/ui.go
+++ b/server/route/ui.go
@@ -32,14 +32,14 @@ import (
 )
 
 // SetUIRoutes sets UI routes
-func SetUIRoutes(e *echo.Group, indexHTML []byte, assets embed.FS) {
-	assetsHandler := buildUIAssetsHander(assets)
+func SetUIRoutes(e *echo.Echo, indexHTML []byte, assets embed.FS) {
+	assetsHandler := buildUIAssetsHandler(assets)
 	e.GET("/_app/*", assetsHandler)
 	e.GET("/css/*", assetsHandler)
 	e.GET("/prism/*", assetsHandler)
 	e.GET("/android*", assetsHandler)
 	e.GET("/apple*", assetsHandler)
-	e.GET("/banner.png", assetsHandler)
+	e.GET("/banner*", assetsHandler)
 	e.GET("/favicon*", assetsHandler)
 	e.GET("/logo*", assetsHandler)
 	e.GET("/site.webmanifest", assetsHandler)
@@ -52,7 +52,7 @@ func buildUIIndexHandler(indexHTML []byte) echo.HandlerFunc {
 	}
 }
 
-func buildUIAssetsHander(assets embed.FS) echo.HandlerFunc {
+func buildUIAssetsHandler(assets embed.FS) echo.HandlerFunc {
 	stream := fs.FS(assets)
 	stream, _ = fs.Sub(stream, "generated/ui")
 	handler := http.FileServer(http.FS(stream))

--- a/server/route/ui.go
+++ b/server/route/ui.go
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package routes
+package route
 
 import (
 	"bytes"
@@ -31,21 +31,30 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// SetAPIRoutes sets api routes
-func SetSwaggerUIRoutes(e *echo.Echo, indexHTML []byte, assets embed.FS) {
-	e.GET("/openapi", buildSwaggerUIHandler(indexHTML))
-	e.GET("/openapi/*", buildSwaggerUIAssetsHander(assets))
+// SetUIRoutes sets UI routes
+func SetUIRoutes(e *echo.Group, indexHTML []byte, assets embed.FS) {
+	assetsHandler := buildUIAssetsHander(assets)
+	e.GET("/_app/*", assetsHandler)
+	e.GET("/css/*", assetsHandler)
+	e.GET("/prism/*", assetsHandler)
+	e.GET("/android*", assetsHandler)
+	e.GET("/apple*", assetsHandler)
+	e.GET("/banner.png", assetsHandler)
+	e.GET("/favicon*", assetsHandler)
+	e.GET("/logo*", assetsHandler)
+	e.GET("/site.webmanifest", assetsHandler)
+	e.GET("/*", buildUIIndexHandler(indexHTML))
 }
 
-func buildSwaggerUIHandler(indexHTML []byte) echo.HandlerFunc {
+func buildUIIndexHandler(indexHTML []byte) echo.HandlerFunc {
 	return func(c echo.Context) (err error) {
 		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTML))
 	}
 }
 
-func buildSwaggerUIAssetsHander(assets embed.FS) echo.HandlerFunc {
+func buildUIAssetsHander(assets embed.FS) echo.HandlerFunc {
 	stream := fs.FS(assets)
-	stream, _ = fs.Sub(stream, "generated")
+	stream, _ = fs.Sub(stream, "generated/ui")
 	handler := http.FileServer(http.FS(stream))
 	return echo.WrapHandler(handler)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/temporalio/ui-server/v2/server/config"
 	"github.com/temporalio/ui-server/v2/server/csrf"
-	"github.com/temporalio/ui-server/v2/server/routes"
+	"github.com/temporalio/ui-server/v2/server/route"
 	"github.com/temporalio/ui-server/v2/server/server_options"
 )
 
@@ -107,15 +107,16 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		panic(err)
 	}
 
-	routes.SetHealthRoute(e)
-	routes.SetAPIRoutes(e, cfgProvider, serverOpts.APIMiddleware)
-	routes.SetAuthRoutes(e, cfgProvider)
+	routes := e.Group(cfg.PublicPath)
+	route.SetHealthRoute(routes)
+	route.SetAPIRoutes(routes, cfgProvider, serverOpts.APIMiddleware)
+	route.SetAuthRoutes(routes, cfgProvider)
 
 	if cfg.EnableOpenAPI {
-		routes.SetSwaggerUIRoutes(e, swaggeruiHTML, swaggeruiAssets)
+		route.SetSwaggerUIRoutes(routes, swaggeruiHTML, swaggeruiAssets)
 	}
 	if cfg.EnableUI {
-		routes.SetUIRoutes(e, uiHTML, uiAssets)
+		route.SetUIRoutes(routes, uiHTML, uiAssets)
 	}
 
 	s := &Server{

--- a/server/server.go
+++ b/server/server.go
@@ -103,20 +103,15 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		)))
 	}
 
-	if err != nil {
-		panic(err)
-	}
-
-	routes := e.Group(cfg.PublicPath)
-	route.SetHealthRoute(routes)
-	route.SetAPIRoutes(routes, cfgProvider, serverOpts.APIMiddleware)
-	route.SetAuthRoutes(routes, cfgProvider)
-
+	e.Pre(route.PublicPath(cfg.PublicPath))
+	route.SetHealthRoute(e)
+	route.SetAPIRoutes(e, cfgProvider, serverOpts.APIMiddleware)
+	route.SetAuthRoutes(e, cfgProvider)
 	if cfg.EnableOpenAPI {
-		route.SetSwaggerUIRoutes(routes, swaggeruiHTML, swaggeruiAssets)
+		route.SetSwaggerUIRoutes(e, swaggeruiHTML, swaggeruiAssets)
 	}
 	if cfg.EnableUI {
-		route.SetUIRoutes(routes, uiHTML, uiAssets)
+		route.SetUIRoutes(e, uiHTML, uiAssets)
 	}
 
 	s := &Server{


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allows serving UI under subpaths, ex `http://localhost:8080/subpath1/namespaces`

## Why?
<!-- Tell your future self why have you made these changes -->

partially resolve https://github.com/temporalio/ui/issues/576

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Started and verified ui-server with `publicPath: /custom-path` set in `development.yml` 

Does not yet work with docker images. TBU https://github.com/temporalio/ui-server/pull/213

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
