### PR TITLE
Stop removing padding in auth encoding to support atob

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,6 @@
+# ui server E2E tests
+
+[![E2E Tests](https://github.com/temporalio/ui-server/actions/workflows/e2e.yml/badge.svg)](https://github.com/temporalio/ui-server/actions/workflows/e2e.yml)
+
+E2E specifies a set of tests that run against a real Temporal server
+

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,28 +1,28 @@
 {
-  "name": "saas-ui-server",
+  "name": "ui-server-e2e",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "saas-ui-server",
+      "name": "ui-server-e2e",
       "version": "1.0.0",
       "dependencies": {
         "dotenv": "^16.0.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.22.2",
+        "@playwright/test": "^1.26.1",
         "@types/node": "^18.0.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
-      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
+      "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.22.2"
+        "playwright-core": "1.26.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
+      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -60,13 +60,13 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
-      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
+      "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.22.2"
+        "playwright-core": "1.26.1"
       }
     },
     "@types/node": {
@@ -81,9 +81,9 @@
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "playwright-core": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
+      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
       "dev": true
     }
   }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npx playwright test"
+    "test": "npx playwright test",
+    "debug": "PWDEBUG=1 npx playwright test"
   },
   "repository": {
     "type": "git",
@@ -18,7 +19,7 @@
   },
   "homepage": "https://github.com/temporalio/ui-server#readme",
   "devDependencies": {
-    "@playwright/test": "^1.22.2",
+    "@playwright/test": "^1.26.1",
     "@types/node": "^18.0.0"
   },
   "dependencies": {

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -77,6 +77,7 @@ func SetUser(c echo.Context, user *User) error {
 			Secure:   c.Request().TLS != nil,
 			HttpOnly: false,
 			Path:     "/",
+			SameSite: http.SameSiteStrictMode,
 		}
 		c.SetCookie(cookie)
 	}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -66,7 +66,7 @@ func SetUser(c echo.Context, user *User) error {
 		return errors.New("unable to serialize user data")
 	}
 
-	s := base64.RawURLEncoding.EncodeToString(b)
+	s := base64.StdEncoding.EncodeToString(b)
 	parts := splitCookie(s)
 
 	for i, p := range parts {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Changed base64 encoding so it includes padding characters
- Set user auth cookie to strict mode for same site policy

## Why?
<!-- Tell your future self why have you made these changes -->

- javascript `atob` requirements (e2e tests failing, the issue was reproing occasionally)
- security

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
