### PR TITLE
Update GitHub Actions workflow triggering conditions

### DIFF
--- a/.github/workflows/docker-cloud.yml
+++ b/.github/workflows/docker-cloud.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   release:
     types:
-      - created
+      - released
 
 jobs:
   publish_to_docker_hub:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       - main
   release:
     types:
-      - created
+      - released
 
 jobs:
   publish_to_docker_hub:


### PR DESCRIPTION
## What was changed
Updated GitHub Actions workflow triggering conditions to `released`

`published`: a release, pre-release, or draft of a release is published
`unpublished`: a release or pre-release is deleted
`created`: a draft is saved, or a release or pre-release is published without previously being saved as a draft
`edited`: a release, pre-release, or draft release is edited
`deleted`: a release, pre-release, or draft release is deleted
`prereleased`: a pre-release is created
`released`: a release is published, or a pre-release is changed to a release

More info: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release

## Why?
Current triggering conditions don't allow for creating a draft release and then publishing it.

