### PR TITLE
Fix v2.8.0 auth upgrade scenario

### DIFF
--- a/server/route/auth.go
+++ b/server/route/auth.go
@@ -149,6 +149,18 @@ func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc
 }
 
 func setCallbackCookie(c echo.Context, name, value string) {
+	// Explicitly expire pre v2.8.0 state and nonce cookies.
+	// As they had different path, they were not being cleared and in some cases result in "state did not match" error.
+	cookiePreV280 := &http.Cookie{
+		Name:     name,
+		Value:    "",
+		MaxAge:   -1,
+		Secure:   c.Request().TLS != nil,
+		Path:     "",
+		HttpOnly: true,
+	}
+	c.SetCookie(cookiePreV280)
+
 	cookie := &http.Cookie{
 		Name:     name,
 		Value:    value,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixes "state did not match" error that could happen for an hour after user logging in in pre v2.8.0 and then upgraded to v2.8.0

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Started UI with v2.6.0 and logged in. 
Stopped v2.6.0
Started UI with v2.8.0 and logged in


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
