### PR TITLE
Fix forwarding Authorization-Extras header

### DIFF
--- a/server/headers/headers.go
+++ b/server/headers/headers.go
@@ -38,8 +38,8 @@ func WithForwardHeaders(headers []string) api.Middleware {
 			func(ctx context.Context, req *http.Request) metadata.MD {
 				md := metadata.MD{}
 				for _, header := range headers {
-					if x, ok := c.Request().Header[header]; ok {
-						md.Append(header, x...)
+					if x := c.Request().Header.Get(header); x != "" {
+						md.Append(header, x)
 					}
 				}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixes forwarding `authorization-extras` header to Temporal Frontend

## Why?
<!-- Tell your future self why have you made these changes -->

This header is sometimes used for authorization instead of `authorization` header

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Verified that Temporal Frontend reads `authorization-extras` header

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
