### PR TITLE
Add docker env to control OIDC auth scopes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -19,6 +19,7 @@ docker run \
     -e TEMPORAL_AUTH_CLIENT_ID=xxxxx-xxxx.apps.googleusercontent.com \
     -e TEMPORAL_AUTH_CLIENT_SECRET=xxxxxxxxxxxxxxx \
     -e TEMPORAL_AUTH_CALLBACK_URL=https://xxxx.com:8080/auth/sso/callback \
+    -e TEMPORAL_AUTH_SCOPES=openid,email,profile \
     -e TEMPORAL_TLS_CA=../ca.cert \
     -e TEMPORAL_TLS_CERT=../cluster.pem \
     -e TEMPORAL_TLS_KEY=../cluster.key \

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -33,16 +33,10 @@ auth:
     clientId: {{ .Env.TEMPORAL_AUTH_CLIENT_ID }}
     clientSecret: {{ .Env.TEMPORAL_AUTH_CLIENT_SECRET }}
     callbackUrl: {{ .Env.TEMPORAL_AUTH_CALLBACK_URL }}
-    scopes:
-      - openid
-      - profile
-      - email
+    scopes: {{ if .Env.TEMPORAL_AUTH_SCOPES }} {{ range $seed := (split .Env.TEMPORAL_AUTH_SCOPES ",") }}
+      - {{ . }} {{ end }} {{ end }}
 codec:
   endpoint: {{ default .Env.TEMPORAL_CODEC_ENDPOINT "" }}
   passAccessToken: {{ default .Env.TEMPORAL_CODEC_PASS_ACCESS_TOKEN "false" }}
-forwardHeaders: # comma separated list of headers to pass from HTTP API requests to Temporal gRPC backend
-{{ if .Env.TEMPORAL_FORWARD_HEADERS }}
-{{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
-  - {{ . }}
-{{ end }}
-{{ end }}
+forwardHeaders: {{ if .Env.TEMPORAL_FORWARD_HEADERS }} {{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
+  - {{ . }} {{ end }} {{ end }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added `TEMPORAL_AUTH_SCOPES` that allows to customize auth scopes when running in docker

## Why?
<!-- Tell your future self why have you made these changes -->

resolve #210

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

built & started docker with OIDC auth setup -> went through login flow. Verified that changing `TEMPORAL_AUTH_SCOPES` results in changes in `docker.yml`

```
docker run \
    --network host \
    -e TEMPORAL_ADDRESS=127.0.0.1:7233 \
    -e TEMPORAL_UI_PORT=8080 \
    -e TEMPORAL_AUTH_ENABLED=true \
    -e TEMPORAL_AUTH_PROVIDER_URL=https://accounts.google.com \
    -e TEMPORAL_AUTH_CLIENT_ID=xxx \
    -e TEMPORAL_AUTH_CLIENT_SECRET=yyy \
    -e TEMPORAL_AUTH_CALLBACK_URL=http://localhost:8080/auth/sso/callback \
    -e TEMPORAL_AUTH_SCOPES=openid,email,profile \
    ui
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
