### PR TITLE
Allow using a custom asset path, overriding the embedded UI assets.

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -39,6 +39,7 @@ type (
 		TLS                 TLS    `yaml:"tls"`
 		Auth                Auth   `yaml:"auth"`
 		EnableUI            bool   `yaml:"enableUi"`
+		UIAssetPath         string `yaml:"uiAssetPath"`
 		EnableOpenAPI       bool   `yaml:"enableOpenApi"`
 		CORS                CORS   `yaml:"cors"`
 		DefaultNamespace    string `yaml:"defaultNamespace"`


### PR DESCRIPTION
## What was changed
Added a config option to use a custom asset directory, replacing the bundled assets.

## Why?
This makes it easy to test UI changes with `server start-dev`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Tested via Temporal CLI PR: `./temporal server start-dev --ui-asset-path $PWD/../ui/.vercel/output/static/` versus `./temporal server start-dev`. Confirmed the adjusted UI is served when the option is passed.

3. Any docs updates needed?
No.