### PR TITLE
Allow configuring UI server host via an environment variable

### DIFF
--- a/docker/config-template.yaml
+++ b/docker/config-template.yaml
@@ -1,4 +1,5 @@
 temporalGrpcAddress: {{ default .Env.TEMPORAL_ADDRESS "127.0.0.1:7233" }}
+host: {{ default .Env.TEMPORAL_UI_HOST "" }}
 port: {{ default .Env.TEMPORAL_UI_PORT "8080" }}
 publicPath: {{ default .Env.TEMPORAL_UI_PUBLIC_PATH "" }}
 enableUi: {{ default .Env.TEMPORAL_UI_ENABLED "true" }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This PR adds a way to configure the UI server bind address / host using an environment variable. Right now you can configure the port using `TEMPORAL_UI_PORT` but not the host.

<!-- Describe what has changed in this PR -->

## Why?

For consistency with the rest of the configuration options and to avoid having to use a configuration file just for one unexposed option.

<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Ran docker build 

```
𝝺 docker build . -t test/ui-server
```

And checked setting the environment variable changed the output log showing the bind address

```
𝝺 docker run -it -e TEMPORAL_UI_HOST=127.0.0.1 test/ui-server
2023/06/13 10:27:21 Loading config; env=docker,configDir=config
2023/06/13 10:27:21 Loading config files=[config/docker.yaml]
...
⇨ http server started on 127.0.0.1:8080
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

Maybe in another repo?
