### PR TITLE
Use a dockerhub PAT instead of the account password

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,10 +21,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Docker meta for Commit image
         id: meta_commit


### PR DESCRIPTION
## What was changed
We now use a dockerhub Personal Access Token (PAT) instead of the account password

## Why?
Over the weekend security changed our docker account to require MFA, so our automated processes need to use the PAT instead of the password