### PR TITLE
Use the same GID/UID as other Temporal projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ ARG TEMPORAL_CLOUD_UI="false"
 
 WORKDIR /home/ui-server
 
-RUN addgroup -g 5000 temporal
-RUN adduser -u 5000 -G temporal -D temporal
+RUN addgroup -g 1000 temporal
+RUN adduser -u 1000 -G temporal -D temporal
 
 RUN mkdir ./config
 


### PR DESCRIPTION
Other Temporal containers use UID/GID = 1000, see for example here https://github.com/temporalio/helm-charts/blob/master/values.yaml#L88

Web UI is the only one using UID 5000, so this patch fixes this inconsistency.