### PR TITLE
chore: upgrade base-server to 1.15.7 and base-builder to 1.14.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.5
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.5
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.7
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.8
 
 FROM ${BASE_BUILDER_IMAGE} AS server-builder
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I upgraded the temporalio/base-server image to 1.15.7, and the temporalio/base-builder image to 1.14.8. 

## Why?
<!-- Tell your future self why have you made these changes -->

I did this to match what was in the [docker builds](https://github.com/temporalio/docker-builds/blob/main/server.Dockerfile) repository.

It looks like base server image is several months old, and as a result, had accumulated some vulnerabilities over time. The purpose of this pull request is to upgrade the base image to resolve most of the vulnerabilities.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I built the docker image locally and compared the vulnerabilities.

### before with 2.25.0

![image](https://github.com/temporalio/ui-server/assets/11479329/9488696b-0363-40b6-870f-6baad2d3eca1)


### now

![image](https://github.com/temporalio/ui-server/assets/11479329/4b7e966d-af0c-47d7-96ce-3399ab14b98a)



3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
