### PR TITLE
Bump Go version in Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.23"
 
       - name: build
         run: make build-server


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Bump the Go version from 1.20 to 1.23 in the test GitHub Action workflow.

## Why?
<!-- Tell your future self why have you made these changes -->

We encountered some issues building the UI server locally and suspect the issue may be caught by the actions here, but the actions are failing sooner.

