### PR TITLE
fix: Remove v prefix from Docker tags in release workflow

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -18,7 +18,8 @@ on:
 
 env:
   GITHUB_REF: ${{ inputs.ref || github.event.ref }}
-  GITHUB_RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
+  GITHUB_RELEASE_TAG_NAME: ${{ inputs.release_tag || github.event.release.tag_name }}
+  GITHUB_RELEASE_VERSION: ${{ startsWith(inputs.release_tag || github.event.release.tag_name, 'v') && substring(inputs.release_tag || github.event.release.tag_name, 1) || inputs.release_tag || github.event.release.tag_name }}
   GITHUB_RELEASE_URL: ${{ inputs.release_url || github.event.release.html_url }}
 
 permissions:
@@ -48,7 +49,7 @@ jobs:
           images: ${{ vars.DOCKER_IMAGE_UI }}
           tags: |
             type=semver,pattern={{version}}
-            ${{ env.GITHUB_RELEASE_TAG }}
+            ${{ env.GITHUB_RELEASE_VERSION }}
             latest
 
       - name: Docker Cloud Build and Push
@@ -103,7 +104,7 @@ jobs:
           client-payload: |
             {
               "ref": "${{ env.GITHUB_REF }}",
-              "release_tag": "${{ env.GITHUB_RELEASE_TAG }}",
+              "release_tag": "${{ env.GITHUB_RELEASE_TAG_NAME }}",
               "release_url": "${{ env.GITHUB_RELEASE_URL }}"
             }
 


### PR DESCRIPTION
## What was changed

Strip the v prefix from GitHub release tags when building Docker images
while preserving the full tag name for downstream dispatch payloads.

## Why?

Pre automation the Docker image build process used the version tag name (e.g.,
`1.2.3`) as the image tag. Post automation the build process uses the GitHub
release tag name (e.g., `v1.2.3`) as the image tag. This change formats the tag
to adhere to the previous convention.

<img width="1245" alt="image" src="https://github.com/user-attachments/assets/47a01829-94f9-47c7-b9f8-e6c2e58b6596" />
