### PR TITLE
feat: Add manual Docker push workflow

### DIFF
--- a/.github/workflows/manual-docker-push.yaml
+++ b/.github/workflows/manual-docker-push.yaml
@@ -1,0 +1,63 @@
+name: Manual Docker Push
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build from (commit SHA, tag, or branch)'
+        required: true
+        type: string
+      version:
+        description: 'Version tag for Docker image (e.g., 2.38.3)'
+        required: true
+        type: string
+      push_latest:
+        description: 'Also update the latest tag'
+        required: false
+        type: boolean
+        default: false
+      image_type:
+        description: 'Which image to push'
+        required: true
+        type: choice
+        options:
+          - ui
+          - cloud-ui
+          - both
+
+permissions:
+  contents: read
+
+jobs:
+  push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout specific ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Docker
+        uses: ./.github/actions/setup-docker
+        with:
+          docker_username: ${{ secrets.DOCKER_USERNAME }}
+          docker_pat: ${{ secrets.DOCKER_PAT }}
+
+      - name: Push UI Image
+        if: ${{ inputs.image_type == 'ui' || inputs.image_type == 'both' }}
+        uses: ./.github/actions/docker-build-push
+        with:
+          images: ${{ vars.DOCKER_IMAGE_UI }}
+          tags: |
+            ${{ inputs.version }}
+            ${{ inputs.push_latest && 'latest' || '' }}
+
+      - name: Push Cloud UI Image
+        if: ${{ inputs.image_type == 'cloud-ui' || inputs.image_type == 'both' }}
+        uses: ./.github/actions/docker-build-push
+        with:
+          images: ${{ vars.DOCKER_IMAGE_CLOUD_UI }}
+          build-args: TEMPORAL_CLOUD_UI=true
+          tags: |
+            ${{ inputs.version }}
+            ${{ inputs.push_latest && 'latest' || '' }}


### PR DESCRIPTION
## Summary
- Add workflow_dispatch action to manually build and push Docker images
- Allows specifying any git ref (commit, tag, branch) to build from
- Enables custom version tagging without creating new releases

## Purpose
This workflow provides a way to fix incorrectly tagged Docker images without the side effects of creating a new GitHub release (which triggers downstream systems, notifications, and version bumps).

## Usage
The workflow can be triggered manually from the Actions tab with:
- **ref**: Git reference to build from (e.g., `v2.38.3`, commit SHA, branch name)
- **version**: Docker tag to apply (e.g., `2.38.3`)
- **push_latest**: Whether to also update the `latest` tag
- **image_type**: Which images to push (`ui`, `cloud-ui`, or `both`)

## Test plan
- [ ] Workflow file is valid YAML
- [ ] Uses existing Docker setup and build-push actions
- [ ] Conditional logic correctly handles image type selection