### PR TITLE
DT-3284: Use GitHub App token for git push operations in workflows

### DIFF
--- a/.github/actions/commit-changes/action.yaml
+++ b/.github/actions/commit-changes/action.yaml
@@ -5,6 +5,12 @@ inputs:
   message:
     description: 'The commit message'
     required: true
+  app-id:
+    description: 'GitHub App ID'
+    required: true
+  private-key:
+    description: 'GitHub App private key'
+    required: true
 
 outputs:
   commit_hash:
@@ -14,6 +20,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Prepare token
+      id: generate_token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+
     - name: Commit changes
       shell: bash
       id: commit_changes
@@ -25,4 +38,6 @@ runs:
         git push
 
         echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      env:
+        GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 

--- a/.github/workflows/on-commit-dispatch.yml
+++ b/.github/workflows/on-commit-dispatch.yml
@@ -31,6 +31,8 @@ jobs:
         uses: ./.github/actions/commit-changes
         with:
           message: "Sync from UI commit ${{ github.sha }}"
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
   commit:
     uses: ./.github/workflows/on-commit.yaml

--- a/.github/workflows/on-release-dispatch.yml
+++ b/.github/workflows/on-release-dispatch.yml
@@ -34,6 +34,8 @@ jobs:
         uses: ./.github/actions/commit-changes
         with:
           message: "Sync from UI release ${{ github.event.client_payload.release_tag }}"
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
       - name: Create GitHub Release
         id: create_release


### PR DESCRIPTION
## Summary
Updates the commit-changes GitHub Action to use GitHub App authentication instead of default GITHUB_TOKEN to enable proper push permissions in workflow contexts.

## Motivation
The commit-changes action needs to push commits during automated workflows. Using the default GITHUB_TOKEN can have limitations for push operations in certain workflow contexts. This change ensures proper permissions by using a GitHub App token, following the same pattern already established in the on-release workflow.

## Changes
- Added `app-id` and `private-key` inputs to the commit-changes action
- Added token generation step using `actions/create-github-app-token@v2`
- Set `GITHUB_TOKEN` environment variable in commit step to use generated token
- Updated both dispatch workflows to pass app credentials

## Testing
The changes will be validated when the next dispatch workflow runs.

## Jira
[DT-3284](https://temporalio.atlassian.net/browse/DT-3284)

[DT-3284]: https://temporalio.atlassian.net/browse/DT-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ