### PR TITLE
DT-3284: Fix GitHub App authentication for push operations

### DIFF
--- a/.github/actions/commit-changes/action.yaml
+++ b/.github/actions/commit-changes/action.yaml
@@ -27,17 +27,21 @@ runs:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
 
+    - name: Configure Git
+      shell: bash
+      run: |
+        echo ${{ steps.generate_token.outputs.token }} | gh auth login --with-token
+        gh auth status -a
+        git config --global user.name "temporal-cicd[bot]"
+        git config --global user.email "gh-action@users.noreply.github.com"
+
     - name: Commit changes
       shell: bash
       id: commit_changes
       run: |
-        git config --local user.name 'Temporal Data (cicd)'
-        git config --local user.email 'commander-data@temporal.io'
         git add .
         git commit -m "${{ inputs.message }}"
         git push
 
         echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-      env:
-        GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
## Summary
Updates the commit-changes action to properly authenticate with GitHub CLI before pushing, addressing repository rule violations.

## Problem
Push operations were failing with error: "Required workflow 'Check for CODEOWNERS' is not satisfied"

## Solution
- Add separate "Configure Git" step that authenticates with gh CLI using the App token
- Use `temporal-cicd[bot]` as the commit user
- Remove GITHUB_TOKEN env var in favor of gh auth login

## Testing
The changes will be validated when the next dispatch workflow runs after merging.

## Jira
[DT-3284](https://temporalio.atlassian.net/browse/DT-3284)

[DT-3284]: https://temporalio.atlassian.net/browse/DT-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ