### PR TITLE
DT-3284: Fix GitHub App authentication flow in dispatch workflows

### DIFF
--- a/.github/actions/commit-changes/action.yaml
+++ b/.github/actions/commit-changes/action.yaml
@@ -5,12 +5,6 @@ inputs:
   message:
     description: 'The commit message'
     required: true
-  app-id:
-    description: 'GitHub App ID'
-    required: true
-  private-key:
-    description: 'GitHub App private key'
-    required: true
 
 outputs:
   commit_hash:
@@ -20,21 +14,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Prepare token
-      id: generate_token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.private-key }}
-
-    - name: Configure Git
-      shell: bash
-      run: |
-        echo ${{ steps.generate_token.outputs.token }} | gh auth login --with-token
-        gh auth status -a
-        git config --global user.name "temporal-cicd[bot]"
-        git config --global user.email "gh-action@users.noreply.github.com"
-
     - name: Commit changes
       shell: bash
       id: commit_changes

--- a/.github/workflows/on-commit-dispatch.yml
+++ b/.github/workflows/on-commit-dispatch.yml
@@ -16,8 +16,25 @@ jobs:
       commit_hash: ${{ steps.commit_changes.outputs.commit_hash }}
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+
       - name: Checkout ui-server
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          echo ${{ steps.generate_token.outputs.token }} | gh auth login --with-token
+          gh auth status -a
+          git config --global user.name "temporal-cicd[bot]"
+          git config --global user.email "gh-action@users.noreply.github.com"
 
       - name: Download and Build UI
         uses: ./.github/actions/download-and-build-ui
@@ -31,8 +48,6 @@ jobs:
         uses: ./.github/actions/commit-changes
         with:
           message: "Sync from UI commit ${{ github.sha }}"
-          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
-          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
   commit:
     uses: ./.github/workflows/on-commit.yaml

--- a/.github/workflows/on-release-dispatch.yml
+++ b/.github/workflows/on-release-dispatch.yml
@@ -19,8 +19,25 @@ jobs:
       release_url: ${{ steps.create_release.outputs.url }}
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+
       - name: Checkout ui-server
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          echo ${{ steps.generate_token.outputs.token }} | gh auth login --with-token
+          gh auth status -a
+          git config --global user.name "temporal-cicd[bot]"
+          git config --global user.email "gh-action@users.noreply.github.com"
 
       - name: Download and Build UI
         uses: ./.github/actions/download-and-build-ui
@@ -34,8 +51,6 @@ jobs:
         uses: ./.github/actions/commit-changes
         with:
           message: "Sync from UI release ${{ github.event.client_payload.release_tag }}"
-          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
-          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
       - name: Create GitHub Release
         id: create_release


### PR DESCRIPTION
## Summary
Moves GitHub App authentication setup to the workflows themselves to ensure proper token usage throughout the entire workflow.

## Problem
Push operations were failing with: "Required workflow 'Check for CODEOWNERS' is not satisfied"

The issue was that we need the GitHub App token from the very beginning of the workflow, including for the checkout step.

## Solution
Following the pattern from temporal-worker-controller release workflow:
- Generate GitHub App token as first step in dispatch workflows  
- Use token for checkout with fetch-depth: 0
- Configure Git and gh CLI auth after checkout
- Simplify commit-changes action to only handle commits

## Testing
The changes will be validated when the next dispatch workflow runs after merging.

## Jira
[DT-3284](https://temporalio.atlassian.net/browse/DT-3284)

[DT-3284]: https://temporalio.atlassian.net/browse/DT-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ