### PR TITLE
VLN-1357: remediate unpinned-github-actions

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -17,13 +17,13 @@ runs:
   steps:
     - name: Docker meta for Release image
       id: meta_release
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
       with:
         images: ${{ inputs.images }}
         tags: ${{ inputs.tags }}
 
     - name: Build and Push Docker Image
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
       with:
         context: .
         push: true

--- a/.github/actions/download-and-build-ui/action.yaml
+++ b/.github/actions/download-and-build-ui/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: Download UI
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         repository: ${{ inputs.upstream_org }}/${{ inputs.upstream_repo }}
         ref: ${{ inputs.ref }}

--- a/.github/actions/setup-docker/action.yaml
+++ b/.github/actions/setup-docker/action.yaml
@@ -13,14 +13,13 @@ runs:
   using: 'composite'
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
 
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         username: ${{ inputs.docker_username }}
         password: ${{ inputs.docker_pat }}
-

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -9,13 +9,13 @@ runs:
   using: 'composite'
 
   steps:
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
       with:
         go-version: '1.23'
 
     - name: Setup Protoc
       if : ${{ inputs.token }}
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
       with:
         version: '3.x'
         repo-token: ${{ inputs.token }}

--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -6,13 +6,13 @@ runs:
   steps:
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       with:
         run_install: false
         version: 10
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
@@ -25,7 +25,7 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       name: Setup pnpm cache
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/manual-docker-push.yaml
+++ b/.github/workflows/manual-docker-push.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout specific ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/on-commit-dispatch.yml
+++ b/.github/workflows/on-commit-dispatch.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
       - name: Checkout ui-server
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/on-commit.yaml
+++ b/.github/workflows/on-commit.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ui-server
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.GITHUB_REF }}
 

--- a/.github/workflows/on-release-dispatch.yml
+++ b/.github/workflows/on-release-dispatch.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
       - name: Checkout ui-server
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           target_commitish: ${{ steps.commit_changes.outputs.commit_hash }}
           generate_release_notes: true

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ui-server
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ env.GITHUB_REF }}
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merged branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ env.GITHUB_REF }}
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: '~> v2'
           args: release
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Prepare token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
@@ -99,7 +99,7 @@ jobs:
           repositories: ${{ vars.DOWNSTREAM_REPO }}
 
       - name: Dispatch to SaaS UI Server
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ steps.generate_token.outputs.token }}
           repository: ${{ vars.DOWNSTREAM_ORG }}/${{ vars.DOWNSTREAM_REPO }}
@@ -110,4 +110,3 @@ jobs:
               "release_tag": "${{ env.GITHUB_RELEASE_TAG_NAME }}",
               "release_url": "${{ env.GITHUB_RELEASE_URL }}"
             }
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
         uses: ./.github/actions/setup-go


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/ui-server</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1357">VLN-1357</a></td></tr>
</table>

## Summary

- `.github/actions/setup-go/action.yaml`: Pinned `actions/setup-go@v4` and `arduino/setup-protoc@v1` to full commit SHAs with exact semver comments.
- `.github/actions/docker-build-push/action.yml`: Pinned `docker/metadata-action@v4` and `docker/build-push-action@v4` to full commit SHAs with exact semver comments.
- `.github/actions/setup-docker/action.yaml`: Pinned `docker/setup-qemu-action@v2`, `docker/setup-buildx-action@v2`, and `docker/login-action@v3` to full commit SHAs with exact semver comments.
- `.github/actions/setup-node/action.yaml`: Pinned `pnpm/action-setup@v4`, `actions/setup-node@v4`, and `actions/cache@v3` to full commit SHAs with exact semver comments.
- `.github/actions/download-and-build-ui/action.yaml`: Pinned `actions/checkout@v3` to a full commit SHA with an exact semver comment.
- `.github/workflows/on-commit-dispatch.yml`: Pinned `actions/create-github-app-token@v2` and `actions/checkout@v4` to full commit SHAs with exact semver comments.
- `.github/workflows/on-release-dispatch.yml`: Pinned `actions/create-github-app-token@v2`, `actions/checkout@v4`, and `softprops/action-gh-release@v2` to full commit SHAs with exact semver comments.
- `.github/workflows/manual-docker-push.yaml`: Pinned `actions/checkout@v4` to a full commit SHA with an exact semver comment.
- `.github/workflows/on-commit.yaml`: Pinned `actions/checkout@v4` to a full commit SHA with an exact semver comment.
- `.github/workflows/on-release.yaml`: Pinned `actions/checkout@v4`, `goreleaser/goreleaser-action@v6`, `actions/create-github-app-token@v2`, and `peter-evans/repository-dispatch@v3` to full commit SHAs with exact semver comments.
- `.github/workflows/test.yml`: Pinned `actions/checkout@v4` to a full commit SHA with an exact semver comment.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix