### PR TITLE
Remove stale ui/assets/local before copying fresh build

### DIFF
--- a/.github/actions/download-and-build-ui/action.yaml
+++ b/.github/actions/download-and-build-ui/action.yaml
@@ -41,5 +41,9 @@ runs:
       shell: bash
       run: |
         rm -rf server/proto/dependencies/api
+        # Remove stale build output before overlaying the fresh build.
+        # ui/assets/local holds content-hashed assets; cp -r only overwrites
+        # same-name files, so changed chunks accumulate old-hash copies forever.
+        rm -rf ui/assets/local
         cp -r ui-release/server/* ./
         rm -rf ui-release


### PR DESCRIPTION
## Summary

- Adds `rm -rf ui/assets/local` before the `cp -r` overlay in the download-and-build-ui action
- `ui/assets/local` contains content-hashed assets; since `cp -r` only overwrites files with matching names, old-hash chunks from previous builds accumulate indefinitely
- Clearing the directory before copying ensures the tree only contains assets from the current build

## Test plan

- [ ] Trigger a sync workflow and confirm `ui/assets/local` contains only assets from the new build
- [ ] Verify no stale `*.js`/`*.css` chunks from prior builds remain