### PR TITLE
fix(ci): make UI sync push race-safe and stop double Docker builds

### DIFF
--- a/.github/actions/commit-changes/action.yaml
+++ b/.github/actions/commit-changes/action.yaml
@@ -1,10 +1,21 @@
-name: 'Docker Build and Push'
-description: 'Build and push Docker images'
+name: 'Commit Changes'
+description: 'Overlays the built UI onto the latest branch tip and pushes, retrying if the branch moves'
 
 inputs:
   message:
     description: 'The commit message'
     required: true
+  build_dir:
+    description: 'Directory holding the built UI output to overlay onto the repo root'
+    required: true
+  branch:
+    description: 'Branch to commit onto'
+    required: false
+    default: 'main'
+  attempts:
+    description: 'How many times to re-anchor and retry the push'
+    required: false
+    default: '5'
 
 outputs:
   commit_hash:
@@ -17,10 +28,49 @@ runs:
     - name: Commit changes
       shell: bash
       id: commit_changes
+      env:
+        MESSAGE: ${{ inputs.message }}
+        BUILD_DIR: ${{ inputs.build_dir }}
+        BRANCH: ${{ inputs.branch }}
+        ATTEMPTS: ${{ inputs.attempts }}
       run: |
-        git add .
-        git commit -m "${{ inputs.message }}"
-        git push
+        set -euo pipefail
 
-        echo "commit_hash=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        for attempt in $(seq 1 "$ATTEMPTS"); do
+          # Re-anchor on the live branch tip before every attempt.
+          #
+          # actions/checkout fetches the SHA that github.sha was pinned to when the
+          # repository_dispatch event was created, and force-rewinds origin/main to
+          # it. A run that waits in the queue therefore starts from a base that is
+          # already several commits stale, and another sync can land while this one
+          # builds. Both cases end in a non-fast-forward push, so re-read the tip
+          # here instead of trusting the checkout.
+          git fetch origin "$BRANCH"
+          git reset --hard "origin/$BRANCH"
 
+          # The build is a full replacement of these paths, not a delta, so
+          # re-applying it onto a newer base loses nothing. Everything outside
+          # these paths comes from the reset above and is preserved.
+          rm -rf server/proto/dependencies/api ui/assets/local
+          cp -r "$BUILD_DIR"/* ./
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit: $BRANCH already matches this build."
+            echo "commit_hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "$MESSAGE"
+
+          if git push origin "HEAD:$BRANCH"; then
+            echo "commit_hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Push rejected on attempt $attempt of $ATTEMPTS: $BRANCH moved. Re-anchoring."
+          sleep $(( RANDOM % 10 + 5 ))
+        done
+
+        echo "::error::Could not push to $BRANCH after $ATTEMPTS attempts."
+        exit 1

--- a/.github/actions/download-and-build-ui/action.yaml
+++ b/.github/actions/download-and-build-ui/action.yaml
@@ -1,5 +1,5 @@
 name: Download and Build UI
-description: Downloads, builds, and copies temporalio/ui from a given SHA
+description: Downloads and builds temporalio/ui from a given SHA, staged for overlay
 
 inputs:
   ref:
@@ -14,6 +14,11 @@ inputs:
   upstream_repo:
     description: 'Upstream repository of the UI'
     required: true
+
+outputs:
+  build_dir:
+    description: 'Directory holding the built UI output, ready to overlay onto the repo root'
+    value: ${{ steps.stage_build.outputs.build_dir }}
 
 runs:
   using: 'composite'
@@ -37,13 +42,16 @@ runs:
         pnpm install
         pnpm build:server
 
-    - name: Copy UI to server
+    - name: Stage build output
+      id: stage_build
       shell: bash
       run: |
-        rm -rf server/proto/dependencies/api
-        # Remove stale build output before overlaying the fresh build.
-        # ui/assets/local holds content-hashed assets; cp -r only overwrites
-        # same-name files, so changed chunks accumulate old-hash copies forever.
-        rm -rf ui/assets/local
-        cp -r ui-release/server/* ./
+        set -euo pipefail
+        # Stage outside the working tree so commit-changes can re-apply the build
+        # after resetting onto a newer main. See that action for why it retries.
+        BUILD_DIR="$RUNNER_TEMP/ui-build"
+        rm -rf "$BUILD_DIR"
+        mkdir -p "$BUILD_DIR"
+        cp -r ui-release/server/* "$BUILD_DIR"/
         rm -rf ui-release
+        echo "build_dir=$BUILD_DIR" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/on-commit-dispatch.yml
+++ b/.github/workflows/on-commit-dispatch.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          ref: main
           fetch-depth: 0
 
       - name: Configure Git
@@ -37,6 +38,7 @@ jobs:
           git config --global user.email "gh-action@users.noreply.github.com"
 
       - name: Download and Build UI
+        id: build_ui
         uses: ./.github/actions/download-and-build-ui
         with:
           ref: ${{ github.event.client_payload.ref }}
@@ -47,11 +49,5 @@ jobs:
         id: commit_changes
         uses: ./.github/actions/commit-changes
         with:
-          message: "Sync from UI commit ${{ github.sha }}"
-
-  commit:
-    uses: ./.github/workflows/on-commit.yaml
-    needs: [sync]
-    secrets: inherit
-    with:
-      ref: ${{ needs.sync.outputs.commit_hash }}
+          message: "Sync from UI commit ${{ github.event.client_payload.ref }}"
+          build_dir: ${{ steps.build_ui.outputs.build_dir }}

--- a/.github/workflows/on-release-dispatch.yml
+++ b/.github/workflows/on-release-dispatch.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          ref: main
           fetch-depth: 0
 
       - name: Configure Git
@@ -40,6 +41,7 @@ jobs:
           git config --global user.email "gh-action@users.noreply.github.com"
 
       - name: Download and Build UI
+        id: build_ui
         uses: ./.github/actions/download-and-build-ui
         with:
           ref: ${{ github.event.client_payload.ref }}
@@ -51,6 +53,7 @@ jobs:
         uses: ./.github/actions/commit-changes
         with:
           message: "Sync from UI release ${{ github.event.client_payload.release_tag }}"
+          build_dir: ${{ steps.build_ui.outputs.build_dir }}
 
       - name: Create GitHub Release
         id: create_release


### PR DESCRIPTION
## Why

The commit sync intermittently fails with a non-fast-forward push ([run 34620798780](https://github.com/temporalio/ui-server/actions/runs/34620798780)).

It looks like two commit syncs colliding, but it is not. The loser was a commit sync and the winner was the **release** sync — and their pushes never overlapped. A mutex would not have prevented it.

The real cause is in the checkout. `actions/checkout` fetches the SHA that `github.sha` was pinned to when the `repository_dispatch` event was created, and force-rewinds `origin/main` to it:

```
git rev-parse refs/remotes/origin/main
a1f4261bee...                                       ← live tip, correct
git fetch origin +60898caf54...:refs/remotes/origin/main
 + a1f4261bee...60898caf54 -> origin/main (forced update)   ← rewound backward
git log -1 --format=%H
60898caf54...                                       ← built on a 2-commit-stale base
```

That run sat in the queue for 5m36s. A commit sync and a release sync both landed in the meantime, so it pushed from two commits behind.

| Time | Event |
|---|---|
| 16:14:00 | Commit sync A pushes `1d19ef53` |
| 16:14:03 | Commit sync B dispatched → `github.sha` pinned at `60898caf`, already stale |
| 16:19:28 | Release sync pushes `a1f4261b` (v2.54.1) |
| 16:19:39 | B's job finally starts, 5m36s after dispatch |
| 16:20:09 | B's checkout rewinds `origin/main` back to `60898caf` |
| 16:21:14 | B pushes → rejected ❌ |

Because the stale base is pinned at dispatch time, queueing runs behind a lock would make this *more* likely, not less — a longer wait means a staler base.

## What changed

**`commit-changes` re-anchors and retries.** It re-reads the live branch tip before every attempt instead of trusting the checkout, re-applies the build, and retries the push up to 5 times with jitter.

This is safe because a sync is a **full replacement** of the synced paths, not a delta, so re-applying it onto a newer base loses nothing. Everything outside those paths comes from the `reset --hard` and is preserved.

**`download-and-build-ui` stages to `RUNNER_TEMP`** so the overlay can be re-applied on each attempt.

**`on-commit-dispatch` no longer calls `on-commit.yaml`.** The bot pushes with an App token, which already fires that workflow's `push` trigger. Every sync was building the image twice:

| Run | Job | Window | Tags pushed |
|---|---|---|---|
| 34620631607 | nested `commit` | 16:14:46 → 16:26:52 | `latest`, `sha-60898ca` |
| 34620802492 | `On Commit` (push) | 16:14:44 → 16:27:06 | `latest`, `sha-1d19ef5` |

Two builds of the same commit, started 2 seconds apart, racing to push `temporaliotest/ui:latest`. ~12 minutes of runner time wasted per sync. The nested job also read `github.sha` for its tag, so `temporaliotest/ui:sha-60898ca` actually contains the build of `1d19ef53` — a mislabeled image for anyone pinning a test image by SHA. Deleting the nested job fixes both.

The release path keeps its nested call: `softprops/action-gh-release` uses `GITHUB_TOKEN`, which does not fire workflows.

**The commit message named the wrong SHA.** `message: "Sync from UI commit ${{ github.sha }}"` used the stale ui-server SHA while claiming to name a UI commit. Run A built UI commit `8ac7a8ef` but wrote `Sync from UI commit 60898caf…`, and `60898caf` is a ui-server commit. Every sync commit in `main`'s history names the wrong repo. It now uses `client_payload.ref`.

**Both dispatch workflows check out `main` explicitly**, so composite actions are loaded from the current tree rather than a stale one.

## Testing

Ran the shipped retry script against a simulated racing push: a competing commit lands after the first `fetch` and before the first `push`.

- Attempt 1 rejected, attempt 2 re-anchored and pushed ✅
- The racer's unrelated Go change survived, not reverted ✅
- Stale asset chunks and the competing sync's chunk both removed ✅
- Linear history, no merge commit ✅
- Re-run with an unchanged build is a clean no-op: exits 0, reports the existing SHA, pushes nothing ✅

## Not included

No `concurrency` group. It does not address this failure, and a group shared by both dispatch workflows holds only one pending run, so a third dispatch would silently cancel a pending release sync. Worth revisiting as a second layer once this has soaked, but the retry makes it optional rather than load-bearing.